### PR TITLE
feat: isolated admission for generated Python

### DIFF
--- a/openpine/runtime/engine.py
+++ b/openpine/runtime/engine.py
@@ -12,6 +12,7 @@ from typing import Any
 from marketdata_provider.contracts import Bar
 
 from openpine.integrations import import_library
+from openpine.runtime.isolated_worker import IsolatedWorkerError, require_isolated_or_scan
 
 
 @dataclass(frozen=True)
@@ -168,6 +169,10 @@ def _validate_production_compile_artifact(
 
 
 def _load_generated_module(path: Path, source_id: str, artifact_id: str) -> Any:
+    try:
+        require_isolated_or_scan(path)
+    except IsolatedWorkerError as exc:
+        raise BacktestArtifactError(str(exc)) from exc
     module_name = (
         "openpine_generated_"
         f"{source_id.replace('-', '_').replace(':', '_')}_"

--- a/openpine/runtime/isolated_worker.py
+++ b/openpine/runtime/isolated_worker.py
@@ -77,3 +77,41 @@ def require_isolated_or_scan(path: Path) -> IsolatedAdmission:
         # gate is the first control; the worker process is the next step.
         return admission
     return admission
+
+
+_WORKER_SNIPPET = r'''
+import ast, json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8")
+tree = ast.parse(source, filename=str(path))
+classes = [n.name for n in tree.body if isinstance(n, ast.ClassDef)]
+print(json.dumps({"ok": True, "classes": classes}))
+'''
+
+
+def inspect_generated_in_process(path: Path, *, timeout_sec: float = 5.0) -> dict[str, object]:
+    import subprocess
+    import sys
+
+    admit_generated_source(path)
+    completed = subprocess.run(
+        [sys.executable, "-I", "-c", _WORKER_SNIPPET, str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_sec,
+        env={
+            "PYTHONHASHSEED": "0",
+            "OPENPINE_WORKER": "1",
+            "PATH": "",
+        },
+    )
+    if completed.returncode != 0:
+        raise IsolatedWorkerError(completed.stderr.strip() or "isolated worker failed")
+    import json
+
+    payload = json.loads(completed.stdout)
+    if payload.get("ok") is not True:
+        raise IsolatedWorkerError("isolated worker returned unsuccessful payload")
+    return payload

--- a/openpine/runtime/isolated_worker.py
+++ b/openpine/runtime/isolated_worker.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import ast
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+FORBIDDEN_IMPORTS = frozenset(
+    {
+        "socket",
+        "subprocess",
+        "ctypes",
+        "multiprocessing",
+        "pickle",
+        "pathlib",
+        "http",
+        "urllib",
+        "requests",
+    }
+)
+FORBIDDEN_NAMES = frozenset({"exec", "eval", "compile", "__import__", "open"})
+
+
+class IsolatedWorkerError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class IsolatedAdmission:
+    path: str
+    imports: tuple[str, ...]
+    forbidden: tuple[str, ...]
+
+
+def scan_generated_source(path: Path) -> IsolatedAdmission:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    imports: list[str] = []
+    forbidden: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                imports.append(alias.name)
+                if root in FORBIDDEN_IMPORTS:
+                    forbidden.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".", 1)[0]
+            imports.append(node.module)
+            if root in FORBIDDEN_IMPORTS:
+                forbidden.append(node.module)
+        elif isinstance(node, ast.Name) and node.id in FORBIDDEN_NAMES:
+            forbidden.append(node.id)
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in FORBIDDEN_NAMES:
+                forbidden.append(node.func.id)
+    return IsolatedAdmission(path=str(path), imports=tuple(imports), forbidden=tuple(dict.fromkeys(forbidden)))
+
+
+def admit_generated_source(path: Path) -> IsolatedAdmission:
+    admission = scan_generated_source(path)
+    if admission.forbidden:
+        raise IsolatedWorkerError(
+            f"generated artifact failed isolated admission: {', '.join(admission.forbidden)}"
+        )
+    return admission
+
+
+def generated_execution_mode() -> str:
+    return os.environ.get("OPENPINE_GENERATED_EXECUTION", "in_process")
+
+
+def require_isolated_or_scan(path: Path) -> IsolatedAdmission:
+    admission = admit_generated_source(path)
+    if generated_execution_mode() == "isolated":
+        # Process isolation is required for 5.0 production. This admission
+        # gate is the first control; the worker process is the next step.
+        return admission
+    return admission

--- a/tests/test_isolated_worker.py
+++ b/tests/test_isolated_worker.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from openpine.runtime.isolated_worker import IsolatedWorkerError, admit_generated_source
+from openpine.runtime.isolated_worker import (
+    IsolatedWorkerError,
+    admit_generated_source,
+    inspect_generated_in_process,
+)
 
 
 def test_safe_generated_source_is_admitted(tmp_path: Path) -> None:
@@ -18,3 +22,11 @@ def test_socket_import_is_rejected(tmp_path: Path) -> None:
     path.write_text("import socket\n")
     with pytest.raises(IsolatedWorkerError, match="socket"):
         admit_generated_source(path)
+
+
+def test_inspect_generated_in_separate_process(tmp_path: Path) -> None:
+    path = tmp_path / "generated_strategy.py"
+    path.write_text("class GeneratedStrategy:\n    pass\n")
+    payload = inspect_generated_in_process(path)
+    assert payload["ok"] is True
+    assert "GeneratedStrategy" in payload["classes"]

--- a/tests/test_isolated_worker.py
+++ b/tests/test_isolated_worker.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+
+from openpine.runtime.isolated_worker import IsolatedWorkerError, admit_generated_source
+
+
+def test_safe_generated_source_is_admitted(tmp_path: Path) -> None:
+    path = tmp_path / "generated_strategy.py"
+    path.write_text("from pinelib import PineRuntime\n\nclass GeneratedStrategy:\n    pass\n")
+    admission = admit_generated_source(path)
+    assert "pinelib" in admission.imports
+    assert admission.forbidden == ()
+
+
+def test_socket_import_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "generated_strategy.py"
+    path.write_text("import socket\n")
+    with pytest.raises(IsolatedWorkerError, match="socket"):
+        admit_generated_source(path)


### PR DESCRIPTION
## Why
OpenPine 5.0: generated Python is untrusted and must not be imported blindly.

## What
- AST admission scan before import
- reject socket/subprocess/ctypes/exec/eval/open
- hook into generated module loader
- default remains in-process after admission so 4.0.2 still runs

Does not move v4.0.2. Full OS worker process is the next increment.