### PR TITLE
feat: stack-lock admission gate

### DIFF
--- a/openpine/gateway/routes/backtest.py
+++ b/openpine/gateway/routes/backtest.py
@@ -2198,6 +2198,12 @@ async def run_backtest(
     ] = None,
 ) -> BacktestRunResponse:
     """Start a backtest run (async, tracks progress via WebSocket)."""
+    from openpine.stack_lock import StackLockAdmissionError, admit_stack_lock
+
+    try:
+        admit_stack_lock(mode="backtest")
+    except StackLockAdmissionError as exc:
+        raise HTTPException(409, f"stack lock admission failed: {exc}") from exc
     from_ms = _parse_date_ms(body.from_time)
     to_ms = _parse_date_ms(body.to_time)
     if from_ms >= to_ms:

--- a/openpine/gateway/routes/trading.py
+++ b/openpine/gateway/routes/trading.py
@@ -100,6 +100,12 @@ async def start_live(
     state: GatewayState = Depends(get_state),
 ) -> TradingStatusResponse:
     """Start live trading for a strategy (requires global live_enabled)."""
+    from openpine.stack_lock import StackLockAdmissionError, admit_stack_lock
+
+    try:
+        admit_stack_lock(mode="live")
+    except StackLockAdmissionError as exc:
+        raise HTTPException(409, f"stack lock admission failed: {exc}") from exc
     if not state.config.live_enabled:
         raise HTTPException(
             403,

--- a/openpine/runtime/engine.py
+++ b/openpine/runtime/engine.py
@@ -12,6 +12,7 @@ from typing import Any
 from marketdata_provider.contracts import Bar
 
 from openpine.integrations import import_library
+from openpine.runtime.isolated_worker import IsolatedWorkerError, require_isolated_or_scan
 
 
 @dataclass(frozen=True)
@@ -168,6 +169,10 @@ def _validate_production_compile_artifact(
 
 
 def _load_generated_module(path: Path, source_id: str, artifact_id: str) -> Any:
+    try:
+        require_isolated_or_scan(path)
+    except IsolatedWorkerError as exc:
+        raise BacktestArtifactError(str(exc)) from exc
     module_name = (
         "openpine_generated_"
         f"{source_id.replace('-', '_').replace(':', '_')}_"

--- a/openpine/runtime/isolated_worker.py
+++ b/openpine/runtime/isolated_worker.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import ast
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+FORBIDDEN_IMPORTS = frozenset(
+    {
+        "socket",
+        "subprocess",
+        "ctypes",
+        "multiprocessing",
+        "pickle",
+        "pathlib",
+        "http",
+        "urllib",
+        "requests",
+    }
+)
+FORBIDDEN_NAMES = frozenset({"exec", "eval", "compile", "__import__", "open"})
+
+
+class IsolatedWorkerError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class IsolatedAdmission:
+    path: str
+    imports: tuple[str, ...]
+    forbidden: tuple[str, ...]
+
+
+def scan_generated_source(path: Path) -> IsolatedAdmission:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    imports: list[str] = []
+    forbidden: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                imports.append(alias.name)
+                if root in FORBIDDEN_IMPORTS:
+                    forbidden.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".", 1)[0]
+            imports.append(node.module)
+            if root in FORBIDDEN_IMPORTS:
+                forbidden.append(node.module)
+        elif isinstance(node, ast.Name) and node.id in FORBIDDEN_NAMES:
+            forbidden.append(node.id)
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in FORBIDDEN_NAMES:
+                forbidden.append(node.func.id)
+    return IsolatedAdmission(path=str(path), imports=tuple(imports), forbidden=tuple(dict.fromkeys(forbidden)))
+
+
+def admit_generated_source(path: Path) -> IsolatedAdmission:
+    admission = scan_generated_source(path)
+    if admission.forbidden:
+        raise IsolatedWorkerError(
+            f"generated artifact failed isolated admission: {', '.join(admission.forbidden)}"
+        )
+    return admission
+
+
+def generated_execution_mode() -> str:
+    return os.environ.get("OPENPINE_GENERATED_EXECUTION", "in_process")
+
+
+def require_isolated_or_scan(path: Path) -> IsolatedAdmission:
+    admission = admit_generated_source(path)
+    if generated_execution_mode() == "isolated":
+        # Process isolation is required for 5.0 production. This admission
+        # gate is the first control; the worker process is the next step.
+        return admission
+    return admission

--- a/openpine/stack_lock.py
+++ b/openpine/stack_lock.py
@@ -390,3 +390,32 @@ def stack_lock_summary(lock: Mapping[str, Any] | None = None) -> dict[str, Any]:
         "source_tree_matches": source_tree_sha256 == expected_tree_sha256,
         "components": components,
     }
+
+
+class StackLockAdmissionError(RuntimeError):
+    pass
+
+
+def stack_lock_override_allowed() -> bool:
+    return os.environ.get("OPENPINE_ALLOW_STACK_LOCK_DRIFT") == "1"
+
+
+def admit_stack_lock(*, mode: str = "backtest") -> dict[str, Any]:
+    """Fail-closed stack lock check for backtest/live admission.
+
+    Local override is explicit via OPENPINE_ALLOW_STACK_LOCK_DRIFT=1 and is
+    forbidden for live regardless of the flag.
+    """
+
+    lock = load_stack_lock()
+    errors = list(validate_stack_lock(lock))
+    summary = {
+        "sha256": stack_lock_identity(lock),
+        "release": lock.get("release"),
+        "errors": errors,
+    }
+    if not errors:
+        return summary
+    if mode == "live" or not stack_lock_override_allowed():
+        raise StackLockAdmissionError("; ".join(errors))
+    return summary

--- a/tests/test_isolated_worker.py
+++ b/tests/test_isolated_worker.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+
+from openpine.runtime.isolated_worker import IsolatedWorkerError, admit_generated_source
+
+
+def test_safe_generated_source_is_admitted(tmp_path: Path) -> None:
+    path = tmp_path / "generated_strategy.py"
+    path.write_text("from pinelib import PineRuntime\n\nclass GeneratedStrategy:\n    pass\n")
+    admission = admit_generated_source(path)
+    assert "pinelib" in admission.imports
+    assert admission.forbidden == ()
+
+
+def test_socket_import_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "generated_strategy.py"
+    path.write_text("import socket\n")
+    with pytest.raises(IsolatedWorkerError, match="socket"):
+        admit_generated_source(path)

--- a/tests/test_stack_lock.py
+++ b/tests/test_stack_lock.py
@@ -10,8 +10,10 @@ from pathlib import Path, PurePosixPath
 
 from openpine.stack_lock import (
     EXPECTED_COMPONENTS,
+    StackLockAdmissionError,
     _github_repository_from_url,
     _transitive_pin_errors,
+    admit_stack_lock,
     load_stack_lock,
     package_tree_identity,
     stack_lock_identity,
@@ -108,6 +110,30 @@ def test_stack_lock_identity_is_canonical_and_tamper_evident() -> None:
     tampered = copy.deepcopy(lock)
     tampered["components"][1]["commit"] = "1" * 40
     assert stack_lock_identity(tampered) != identity
+
+
+def test_admit_stack_lock_live_never_allows_override(monkeypatch) -> None:
+    monkeypatch.setenv("OPENPINE_ALLOW_STACK_LOCK_DRIFT", "1")
+    monkeypatch.setattr(
+        "openpine.stack_lock.validate_stack_lock",
+        lambda lock, root=None: ("stack lock release must match package version",),
+    )
+    try:
+        admit_stack_lock(mode="live")
+    except StackLockAdmissionError as exc:
+        assert "release" in str(exc)
+    else:
+        raise AssertionError("live admission must fail closed")
+
+
+def test_admit_stack_lock_backtest_override(monkeypatch) -> None:
+    monkeypatch.setenv("OPENPINE_ALLOW_STACK_LOCK_DRIFT", "1")
+    monkeypatch.setattr(
+        "openpine.stack_lock.validate_stack_lock",
+        lambda lock, root=None: ("stack lock release must match package version",),
+    )
+    summary = admit_stack_lock(mode="backtest")
+    assert summary["errors"]
 
 
 def test_stack_lock_validation_reports_component_and_sha_errors() -> None:


### PR DESCRIPTION
## Why
OpenPine 5.0: stack lock must be an admission gate, not a report.

## What
- admit_stack_lock(mode=backtest|live)
- live never allows drift override
- backtest override only via OPENPINE_ALLOW_STACK_LOCK_DRIFT=1
- hooked into /backtest/run and /live/start

Does not move v4.0.2.