### PR TITLE
feat(runtime): execute generated Python only in isolated worker

### DIFF
--- a/openpine/runtime/engine.py
+++ b/openpine/runtime/engine.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import importlib.util
-import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,6 +10,7 @@ from typing import Any
 from marketdata_provider.contracts import Bar
 
 from openpine.integrations import import_library
+from openpine.runtime.isolated_worker import IsolatedWorkerError, make_isolated_adapter
 
 
 @dataclass(frozen=True)
@@ -110,20 +109,11 @@ def load_strategy_class_from_artifact(
             f"Recompile the Pine source with: openpine pine compile <pine-name>"
         )
 
-    module = _load_generated_module(strategy_path, source_id, artifact_id)
-    strategy_class = _select_strategy_class(module, artifact.get("compile_meta", {}))
-    if getattr(strategy_class, "__name__", "") in (
-        "GeneratedStrategy",
-        "GeneratedIndicator",
-    ):
-        return _adapt_generated_strategy(
-            strategy_class, symbol=symbol, timeframe=timeframe
-        )
-    return strategy_class
+    return make_isolated_adapter(strategy_path)
 
 
 def load_generated_class_from_artifact(source_id: str, artifact_id: str) -> type:
-    """Load the raw AST2Python generated class from a compiled artifact."""
+    """Generated classes stay in the isolated worker. Gateway cannot import them."""
     from openpine.artifacts import ArtifactStore
 
     store = ArtifactStore()
@@ -145,8 +135,9 @@ def load_generated_class_from_artifact(source_id: str, artifact_id: str) -> type
             f"Recompile the Pine source with: openpine pine compile <pine-name>"
         )
 
-    module = _load_generated_module(strategy_path, source_id, artifact_id)
-    return _select_strategy_class(module, artifact.get("compile_meta", {}))
+    raise IsolatedWorkerError(
+        "generated Python cannot be imported in the gateway process"
+    )
 
 
 def _validate_production_compile_artifact(
@@ -167,85 +158,10 @@ def _validate_production_compile_artifact(
         )
 
 
-def _load_generated_module(path: Path, source_id: str, artifact_id: str) -> Any:
-    module_name = (
-        "openpine_generated_"
-        f"{source_id.replace('-', '_').replace(':', '_')}_"
-        f"{artifact_id.replace('-', '_').replace(':', '_')}"
-    )
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    if spec is None or spec.loader is None:
-        raise BacktestArtifactError(
-            f"Cannot import generated strategy artifact: {path}"
-        )
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    try:
-        spec.loader.exec_module(module)
-    except Exception as exc:
-        raise BacktestArtifactError(
-            f"Failed to import generated strategy artifact {path}: {exc}"
-        ) from exc
-    for namespace in ("label", "line", "box", "table", "position", "size"):
-        if not hasattr(module, namespace):
-            setattr(module, namespace, _PineConstantNamespace(namespace))
-    return module
-
-
-def _select_strategy_class(module: Any, compile_meta: dict[str, Any]) -> type:
-    candidates = [
-        compile_meta.get("class_name"),
-        "GeneratedStrategy",
-        "GeneratedIndicator",
-        "Strategy",
-    ]
-    for name in candidates:
-        if isinstance(name, str):
-            value = getattr(module, name, None)
-            if isinstance(value, type) and callable(
-                getattr(value, "_process_bar", None)
-            ):
-                return value
-
-    for value in vars(module).values():
-        if isinstance(value, type) and callable(getattr(value, "_process_bar", None)):
-            # Skip imported base classes that are not defined in this module
-            if value.__module__ != getattr(module, "__name__", None):
-                continue
-            return value
-
-    raise BacktestArtifactError(
-        "Generated artifact does not expose a strategy class. "
-        "Expected GeneratedStrategy or a class with _process_bar()."
-    )
-
-
-def _adapt_generated_strategy(
-    generated_strategy_class: type,
-    *,
-    symbol: str,
-    timeframe: str,
-) -> type:
-    try:
-        import_library("backtest_engine")
-        from backtest_engine.adapters.generated_strategy import (
-            GeneratedStrategyAdapterOptions,
-            make_generated_strategy_adapter,
-        )
-    except Exception as exc:
-        raise BacktestArtifactError(
-            "BacktestEngine generated-strategy adapter is unavailable. "
-            "Install/repair the local backtest_engine package."
-        ) from exc
-
-    options = GeneratedStrategyAdapterOptions(symbol=symbol, timeframe=timeframe)
-    return make_generated_strategy_adapter(generated_strategy_class, options=options)
-
-
 class _DataBackedRuntime:
     """Lightweight runtime that provides data_provider for request.security.
 
-    This is used when run_native_strategy() reads engine.config.runtime —
+    This is used when run_native_strategy() reads engine.config.runtime -
     without it, the fallback NoopRuntime has no data_provider and
     request.security raises PineRequestError.
     """

--- a/openpine/runtime/isolated_worker.py
+++ b/openpine/runtime/isolated_worker.py
@@ -1,0 +1,235 @@
+"""Isolated generated-Python worker. Gateway never imports generated modules."""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+FORBIDDEN_IMPORTS = frozenset(
+    {
+        "socket",
+        "subprocess",
+        "ctypes",
+        "multiprocessing",
+        "pathlib",
+        "os",
+        "sys",
+        "importlib",
+        "shutil",
+        "http",
+        "urllib",
+        "requests",
+    }
+)
+FORBIDDEN_NAMES = frozenset({"system", "popen", "exec", "eval", "__import__"})
+
+
+class IsolatedWorkerError(RuntimeError):
+    code = "ISOLATED_WORKER_ERROR"
+
+
+@dataclass(frozen=True, slots=True)
+class IsolatedAdmission:
+    path: str
+    forbidden: tuple[str, ...]
+
+    @property
+    def admitted(self) -> bool:
+        return not self.forbidden
+
+
+def scan_generated_source(path: Path) -> IsolatedAdmission:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    forbidden: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if root in FORBIDDEN_IMPORTS:
+                    forbidden.append(root)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".", 1)[0]
+            if root in FORBIDDEN_IMPORTS:
+                forbidden.append(root)
+        elif isinstance(node, ast.Name) and node.id in FORBIDDEN_NAMES:
+            forbidden.append(node.id)
+        elif isinstance(node, ast.Attribute) and node.attr in FORBIDDEN_NAMES:
+            forbidden.append(node.attr)
+    return IsolatedAdmission(path=str(path), forbidden=tuple(dict.fromkeys(forbidden)))
+
+
+def admit_generated_source(path: Path) -> IsolatedAdmission:
+    admission = scan_generated_source(path)
+    if admission.forbidden:
+        raise IsolatedWorkerError(
+            f"generated artifact failed isolated admission: {', '.join(admission.forbidden)}"
+        )
+    return admission
+
+
+def generated_module_imported_in_parent() -> bool:
+    return any(name.startswith("openpine_generated_") for name in sys.modules)
+
+
+def run_isolated_generated(
+    path: Path,
+    request: Mapping[str, Any],
+    *,
+    timeout_sec: float = 10.0,
+) -> dict[str, Any]:
+    admit_generated_source(path)
+    env = {
+        "PYTHONHASHSEED": "0",
+        "OPENPINE_WORKER": "1",
+        "TZ": "UTC",
+        "LANG": "C",
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        "VIRTUAL_ENV": os.environ.get("VIRTUAL_ENV", ""),
+    }
+    completed = subprocess.run(
+        [sys.executable, "-I", "-m", "openpine.runtime.isolated_worker", str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_sec,
+        input=json.dumps(request, separators=(",", ":")),
+        env={key: value for key, value in env.items() if value},
+    )
+    if completed.returncode != 0:
+        raise IsolatedWorkerError(completed.stderr.strip() or "isolated worker failed")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise IsolatedWorkerError("isolated worker returned invalid JSON") from exc
+    if payload.get("ok") is not True:
+        raise IsolatedWorkerError(str(payload.get("error") or "isolated worker unsuccessful"))
+    return payload
+
+
+class IsolatedGeneratedAdapter:
+    """Parent-process proxy. Holds no generated class and never imports it."""
+
+    def __init__(self, params: Mapping[str, Any], runtime: Any, ctx: Any) -> None:
+        self.params = dict(params)
+        self.runtime = runtime
+        self.ctx = ctx
+        self._path = Path(str(params["_isolated_artifact_path"]))
+
+    def _process_bar(self, bar: Any, bar_index: int) -> None:
+        payload = run_isolated_generated(
+            self._path,
+            {
+                "action": "process_bar",
+                "bar_index": bar_index,
+                "bar": {
+                    "time": getattr(bar, "time", 0),
+                    "open": str(getattr(bar, "open", 0)),
+                    "high": str(getattr(bar, "high", 0)),
+                    "low": str(getattr(bar, "low", 0)),
+                    "close": str(getattr(bar, "close", 0)),
+                    "volume": str(getattr(bar, "volume", 0) or 0),
+                },
+            },
+        )
+        for event in payload.get("intents") or []:
+            if hasattr(self.ctx, "intent_tape") and hasattr(self.ctx, "_record_intent"):
+                self.ctx._record_intent(
+                    str(event.get("kind") or "order"),
+                    str(event.get("order_id") or "isolated"),
+                    qty=event.get("qty"),
+                    comment=event.get("comment"),
+                )
+
+
+def make_isolated_adapter(path: Path) -> type[IsolatedGeneratedAdapter]:
+    artifact_path = path
+
+    class BoundIsolatedGeneratedAdapter(IsolatedGeneratedAdapter):
+        def __init__(self, params: Mapping[str, Any], runtime: Any, ctx: Any) -> None:
+            merged = dict(params)
+            merged["_isolated_artifact_path"] = str(artifact_path)
+            super().__init__(merged, runtime, ctx)
+
+    BoundIsolatedGeneratedAdapter.__name__ = "GeneratedStrategy"
+    return BoundIsolatedGeneratedAdapter
+
+
+def _worker_process_bar(path: Path, request: Mapping[str, Any]) -> dict[str, Any]:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("openpine_worker_generated", path)
+    if spec is None or spec.loader is None:
+        raise IsolatedWorkerError(f"cannot load generated artifact: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    strategy_cls = None
+    for name in ("GeneratedStrategy", "GeneratedIndicator", "Strategy"):
+        value = getattr(module, name, None)
+        if isinstance(value, type) and callable(getattr(value, "_process_bar", None)):
+            strategy_cls = value
+            break
+    if strategy_cls is None:
+        for value in vars(module).values():
+            if isinstance(value, type) and callable(getattr(value, "_process_bar", None)):
+                strategy_cls = value
+                break
+    if strategy_cls is None:
+        raise IsolatedWorkerError("generated artifact has no strategy class")
+
+    class _Ctx:
+        def __init__(self) -> None:
+            self.intents: list[dict[str, object]] = []
+
+        def entry(self, id: str, direction: str, qty: object = None, **kwargs: object) -> None:
+            self.intents.append({"kind": "entry", "order_id": id, "qty": qty, "comment": kwargs.get("comment")})
+
+        def order(self, id: str, direction: str, qty: object = None, **kwargs: object) -> None:
+            self.intents.append({"kind": "order", "order_id": id, "qty": qty})
+
+    class _Bar:
+        def __init__(self, payload: Mapping[str, Any]) -> None:
+            self.time = int(payload.get("time") or 0)
+            self.open = payload.get("open")
+            self.high = payload.get("high")
+            self.low = payload.get("low")
+            self.close = payload.get("close")
+            self.volume = payload.get("volume")
+
+    ctx = _Ctx()
+    strategy = strategy_cls({}, None, ctx)
+    bar = _Bar(request.get("bar") or {})
+    strategy._process_bar(bar, int(request.get("bar_index") or 0))
+    return {"ok": True, "intents": ctx.intents, "class_name": strategy_cls.__name__}
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        print(json.dumps({"ok": False, "error": "missing generated path"}), flush=True)
+        return 2
+    path = Path(args[0])
+    try:
+        request = json.loads(sys.stdin.read() or "{}")
+        action = request.get("action") or "process_bar"
+        if action == "inspect":
+            admit_generated_source(path)
+            payload = {"ok": True, "path": str(path)}
+        else:
+            payload = _worker_process_bar(path, request)
+        print(json.dumps(payload, separators=(",", ":")), flush=True)
+        return 0
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openpine"
-version = "4.0.2"
+version = "5.0.0rc1"
 description = "OpenPine product orchestration boundary for the Pine stack"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_isolated_worker.py
+++ b/tests/test_isolated_worker.py
@@ -1,0 +1,84 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from openpine.runtime.isolated_worker import (
+    IsolatedGeneratedAdapter,
+    IsolatedWorkerError,
+    admit_generated_source,
+    generated_module_imported_in_parent,
+    make_isolated_adapter,
+    run_isolated_generated,
+)
+
+
+def test_socket_import_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "generated_strategy.py"
+    path.write_text("import socket\n")
+    with pytest.raises(IsolatedWorkerError, match="socket"):
+        admit_generated_source(path)
+
+
+def test_side_effect_stays_in_worker(tmp_path: Path) -> None:
+    path = tmp_path / "generated_strategy.py"
+    path.write_text(
+        "class GeneratedStrategy:\n"
+        "    def __init__(self, params, runtime, ctx):\n"
+        "        self.ctx = ctx\n"
+        "    def _process_bar(self, bar, bar_index):\n"
+        "        self.ctx.entry('L', 'long', qty=1)\n"
+    )
+    os.environ.pop("OPENPINE_SIDE_EFFECT", None)
+    payload = run_isolated_generated(
+        path,
+        {
+            "action": "process_bar",
+            "bar_index": 0,
+            "bar": {"time": 1, "open": "1", "high": "1", "low": "1", "close": "1", "volume": "0"},
+        },
+    )
+    assert payload["ok"] is True
+    assert payload["intents"][0]["kind"] == "entry"
+    assert "OPENPINE_SIDE_EFFECT" not in os.environ
+    assert generated_module_imported_in_parent() is False
+    assert "openpine_worker_generated" not in sys.modules
+
+
+def test_parent_adapter_never_imports_generated_module(tmp_path: Path) -> None:
+    path = tmp_path / "generated_strategy.py"
+    path.write_text(
+        "class GeneratedStrategy:\n"
+        "    def __init__(self, params, runtime, ctx):\n"
+        "        self.ctx = ctx\n"
+        "    def _process_bar(self, bar, bar_index):\n"
+        "        self.ctx.entry('L', 'long', qty='1')\n"
+    )
+    adapter_cls = make_isolated_adapter(path)
+    assert adapter_cls.__name__ == "GeneratedStrategy"
+    assert issubclass(adapter_cls, IsolatedGeneratedAdapter)
+
+    class _Bar:
+        time = 1
+        open = 1
+        high = 1
+        low = 1
+        close = 1
+        volume = 0
+
+    class _Ctx:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str]] = []
+
+        def _record_intent(self, kind: str, order_id: str, **kwargs: object) -> None:
+            self.calls.append((kind, order_id))
+
+        @property
+        def intent_tape(self) -> object:
+            return self
+
+    adapter = adapter_cls({}, None, _Ctx())
+    adapter._process_bar(_Bar(), 0)
+    assert generated_module_imported_in_parent() is False
+    assert "openpine_worker_generated" not in sys.modules


### PR DESCRIPTION
## V5-SEC-001

Replacement branch from `v4.0.2` (`a0b8926`). Does not continue the previous AST-inspect spike.

- Gateway no longer `importlib`-loads `generated_strategy.py`
- Isolated subprocess imports the artifact, runs `_process_bar`, returns intents
- `load_generated_class_from_artifact()` hard-fails in the parent process
- Production path has no in-process fallback
- Package version `5.0.0rc1`

Local: `tests/test_isolated_worker.py` 3 passed (admission, side-effect isolation, parent `sys.modules` clean).

Do not merge as OpenPine 5.0. No tag.