### PR TITLE
feat(stack-lock): admit all side-effecting entrypoints fail-closed

### DIFF
--- a/openpine/cli/runtime_helpers.py
+++ b/openpine/cli/runtime_helpers.py
@@ -405,6 +405,9 @@ def _prepare_strategy_backtest_inputs(
     perf_counter,
     console,
 ):
+    from openpine.stack_lock import admit_stack_lock
+
+    admit_stack_lock(mode="BACKTEST")
     start_ms, end_ms, capture_from_ms, capture_to_ms = (
         _parse_valid_strategy_backtest_window(
             from_date=from_date,

--- a/openpine/gateway/routes/backtest.py
+++ b/openpine/gateway/routes/backtest.py
@@ -2198,6 +2198,13 @@ async def run_backtest(
     ] = None,
 ) -> BacktestRunResponse:
     """Start a backtest run (async, tracks progress via WebSocket)."""
+    from openpine.stack_lock import StackLockAdmissionError, admit_stack_lock
+    from fastapi import HTTPException
+
+    try:
+        admit_stack_lock(mode="BACKTEST")
+    except StackLockAdmissionError as exc:
+        raise HTTPException(409, f"stack lock admission failed: {exc}") from exc
     from_ms = _parse_date_ms(body.from_time)
     to_ms = _parse_date_ms(body.to_time)
     if from_ms >= to_ms:

--- a/openpine/gateway/routes/trading.py
+++ b/openpine/gateway/routes/trading.py
@@ -100,6 +100,13 @@ async def start_live(
     state: GatewayState = Depends(get_state),
 ) -> TradingStatusResponse:
     """Start live trading for a strategy (requires global live_enabled)."""
+    from openpine.stack_lock import StackLockAdmissionError, admit_stack_lock
+    from fastapi import HTTPException
+
+    try:
+        admit_stack_lock(mode="LIVE")
+    except StackLockAdmissionError as exc:
+        raise HTTPException(409, f"stack lock admission failed: {exc}") from exc
     if not state.config.live_enabled:
         raise HTTPException(
             403,

--- a/openpine/stack_lock.py
+++ b/openpine/stack_lock.py
@@ -390,3 +390,76 @@ def stack_lock_summary(lock: Mapping[str, Any] | None = None) -> dict[str, Any]:
         "source_tree_matches": source_tree_sha256 == expected_tree_sha256,
         "components": components,
     }
+
+
+ADMISSION_MODES = frozenset(
+    {
+        "COMPILE",
+        "BACKTEST",
+        "OPTIMIZE",
+        "PARITY",
+        "PAPER",
+        "LIVE",
+        "BACKFILL",
+    }
+)
+
+
+class StackLockAdmissionError(RuntimeError):
+    def __init__(self, message: str, *, code: str, details: Mapping[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.details = dict(details or {})
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "message": str(self), "details": self.details}
+
+
+def normalize_admission_mode(mode: str) -> str:
+    value = str(mode or "").strip().upper()
+    if value not in ADMISSION_MODES:
+        raise StackLockAdmissionError(
+            f"unknown admission mode: {mode}",
+            code="UNKNOWN_ADMISSION_MODE",
+            details={"mode": mode},
+        )
+    return value
+
+
+def local_dev_override_allowed(*, mode: str) -> bool:
+    profile = os.environ.get("OPENPINE_PROFILE", "")
+    flag = os.environ.get("OPENPINE_ALLOW_STACK_LOCK_DRIFT", "")
+    return (
+        mode not in {"LIVE", "PAPER"}
+        and profile == "local-dev"
+        and flag == "1"
+    )
+
+
+def evaluate_stack_lock(*, mode: str) -> dict[str, Any]:
+    resolved = normalize_admission_mode(mode)
+    lock = load_stack_lock()
+    errors = list(validate_stack_lock(lock))
+    override = local_dev_override_allowed(mode=resolved)
+    result = {
+        "admitted": not errors or override,
+        "code": "ADMIT_OK" if not errors else ("STACK_LOCK_DRIFT_OVERRIDE" if override else "STACK_LOCK_DENIED"),
+        "mode": resolved,
+        "sha256": stack_lock_identity(lock),
+        "release": lock.get("release"),
+        "errors": errors,
+        "override": override,
+        "reproducibility": "DEGRADED" if errors and override else "LOCKED",
+    }
+    return result
+
+
+def admit_stack_lock(*, mode: str) -> dict[str, Any]:
+    result = evaluate_stack_lock(mode=mode)
+    if not result["admitted"]:
+        raise StackLockAdmissionError(
+            "; ".join(result["errors"]) or "stack lock denied",
+            code=str(result["code"]),
+            details=result,
+        )
+    return result

--- a/tests/test_stack_lock.py
+++ b/tests/test_stack_lock.py
@@ -10,8 +10,11 @@ from pathlib import Path, PurePosixPath
 
 from openpine.stack_lock import (
     EXPECTED_COMPONENTS,
+    StackLockAdmissionError,
     _github_repository_from_url,
     _transitive_pin_errors,
+    admit_stack_lock,
+    evaluate_stack_lock,
     load_stack_lock,
     package_tree_identity,
     stack_lock_identity,
@@ -108,6 +111,55 @@ def test_stack_lock_identity_is_canonical_and_tamper_evident() -> None:
     tampered = copy.deepcopy(lock)
     tampered["components"][1]["commit"] = "1" * 40
     assert stack_lock_identity(tampered) != identity
+
+
+def test_unknown_mode_is_hard_fail() -> None:
+    try:
+        admit_stack_lock(mode="maybe-live")
+    except StackLockAdmissionError as exc:
+        assert exc.code == "UNKNOWN_ADMISSION_MODE"
+    else:
+        raise AssertionError("unknown mode must fail closed")
+
+
+def test_live_never_allows_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("OPENPINE_ALLOW_STACK_LOCK_DRIFT", "1")
+    monkeypatch.setenv("OPENPINE_PROFILE", "local-dev")
+    monkeypatch.setattr(
+        "openpine.stack_lock.validate_stack_lock",
+        lambda lock, root=None: ("stack lock release must match package version",),
+    )
+    try:
+        admit_stack_lock(mode="live")
+    except StackLockAdmissionError as exc:
+        assert exc.code == "STACK_LOCK_DENIED"
+    else:
+        raise AssertionError("live admission must fail closed")
+
+
+def test_backtest_override_requires_local_dev_profile(monkeypatch) -> None:
+    monkeypatch.setenv("OPENPINE_ALLOW_STACK_LOCK_DRIFT", "1")
+    monkeypatch.delenv("OPENPINE_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "openpine.stack_lock.validate_stack_lock",
+        lambda lock, root=None: ("stack lock release must match package version",),
+    )
+    try:
+        admit_stack_lock(mode="BACKTEST")
+    except StackLockAdmissionError:
+        pass
+    else:
+        raise AssertionError("env flag alone must not override")
+    monkeypatch.setenv("OPENPINE_PROFILE", "local-dev")
+    result = admit_stack_lock(mode="BACKTEST")
+    assert result["override"] is True
+    assert result["reproducibility"] == "DEGRADED"
+    try:
+        evaluate_stack_lock(mode="CLI")
+    except StackLockAdmissionError as exc:
+        assert exc.code == "UNKNOWN_ADMISSION_MODE"
+    else:
+        raise AssertionError("CLI is not a valid admission mode")
 
 
 def test_stack_lock_validation_reports_component_and_sha_errors() -> None:


### PR DESCRIPTION
## V5-ADM-001

Replacement branch from `v4.0.2` (`a0b8926`). Does not continue the previous HTTP-only spike.

- Typed modes: COMPILE / BACKTEST / OPTIMIZE / PARITY / PAPER / LIVE / BACKFILL
- Unknown mode hard-fails with `UNKNOWN_ADMISSION_MODE`
- LIVE and PAPER never honor `OPENPINE_ALLOW_STACK_LOCK_DRIFT`
- Backtest override requires `OPENPINE_PROFILE=local-dev` **and** the drift flag
- One helper used by HTTP `/backtest/run`, HTTP `/live/start`, and CLI backtest prep
- Structured result/error with stable codes

Local: new admission tests passed. Two existing stack-lock packaging tests fail in this dirty tree (`package_tree_identity` changed; isolated wheel sees local marketdata 5.0 needing `openpine_contracts`). Not a merge/tag candidate.

Do not merge as OpenPine 5.0. No tag.