### PR TITLE
fix(storage): adopt preexisting semantic profile migration

### DIFF
--- a/openpine/storage/migrations.py
+++ b/openpine/storage/migrations.py
@@ -13,6 +13,15 @@ from openpine.storage.sqlite_storage import SQLiteStorage
 _MIGRATION_FILE_RE = re.compile(r"^(\d+)_([^.]+)\.sql$")
 
 
+def _schema_already_satisfies_migration(storage: SQLiteStorage, *, version: str, name: str) -> bool:
+    """Recognize legacy runtime-normalized schema before recording a migration."""
+
+    if version != "020" or name != "strategy_semantic_profile":
+        return False
+    columns = storage.execute("PRAGMA table_info(strategy_instances)").fetchall()
+    return any(str(row[1]) == "semantic_profile" for row in columns)
+
+
 def _get_migration_files(migrations_dir: Path) -> list[tuple[int, str, Path]]:
     """Return sorted list of ``(order, name, path)`` for SQL migration files."""
 
@@ -75,10 +84,14 @@ class MigrationRunner:
             description = name.replace("_", " ")
 
             with storage.transaction():
-                # Use the SQLite script parser rather than ``sql.split(';')``;
-                # splitting breaks triggers, CHECK expressions and string values
-                # containing semicolons.
-                storage.execute_script(sql)
+                # Some pre-5.0 runtimes added ``semantic_profile`` through the
+                # strategy registry before migration 020 existed. Record the
+                # migration without replaying its already-satisfied ALTER.
+                if not _schema_already_satisfies_migration(storage, version=version, name=name):
+                    # Use the SQLite script parser rather than ``sql.split(';')``;
+                    # splitting breaks triggers, CHECK expressions and string values
+                    # containing semicolons.
+                    storage.execute_script(sql)
                 storage.execute(
                     """
                     INSERT INTO schema_migrations

--- a/tests/test_migration_upgrade_020.py
+++ b/tests/test_migration_upgrade_020.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from openpine.storage.migrations import MigrationRunner
+from openpine.storage.sqlite_storage import SQLiteStorage
+
+
+def test_migration_020_records_preexisting_semantic_profile_column(tmp_path) -> None:
+    storage = SQLiteStorage(tmp_path / "openpine.sqlite")
+    try:
+        MigrationRunner().run_migrations(storage)
+        storage.execute(
+            "DELETE FROM schema_migrations WHERE version = ?",
+            ("020",),
+        )
+        storage.commit()
+
+        applied = MigrationRunner().run_migrations(storage)
+
+        columns = [
+            str(row[1])
+            for row in storage.execute("PRAGMA table_info(strategy_instances)").fetchall()
+        ]
+        row = storage.execute(
+            "SELECT version, name FROM schema_migrations WHERE version = ?",
+            ("020",),
+        ).fetchone()
+        assert applied == ["strategy_semantic_profile"]
+        assert columns.count("semantic_profile") == 1
+        assert row == ("020", "strategy_semantic_profile")
+    finally:
+        storage.close()


### PR DESCRIPTION
## Summary

- make migration 020 adopt a pre-existing `strategy_instances.semantic_profile` column
- still record the canonical migration version/name/checksum without replaying the duplicate `ALTER TABLE`
- add a regression reproducing the exact production-upgrade shape

## Why

The published 5.0.0 RC.4 sandbox upgrade from the current production database failed with:

```text
sqlite3.OperationalError: duplicate column name: semantic_profile
```

Older runtime schema normalization had already added the column while `schema_migrations` still ended at 019. Migration 020 must recognize that already-satisfied schema rather than aborting startup.

## TDD evidence

RED before implementation:

```text
tests/test_migration_upgrade_020.py
sqlite3.OperationalError: duplicate column name: semantic_profile
```

GREEN after implementation:

- focused migration/storage/registry/ledger pack: 16 passed
- canonical backend release gate: PASS
- coverage: 91.17% (required 90%)
- V5-SEC-001: PASS
- duplicate groups: 0
- architecture oversized files: 0
- distribution hygiene errors: 0
- bounded runner: no OOM/CMA failure, max RSS 644.4 MiB, max temperature 60.6°C

## Release boundary

This PR does not move or recreate the published `v5.0.0rc4` tag and does not deploy production. A new candidate identity/version is required before cutover.
