### PR TITLE
chore(release): promote OpenPine stack to 5.0.0rc5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,13 @@ jobs:
         run: |
           mkdir -p "$RUNNER_TEMP/openpine-candidate"
           python scripts/materialize_stack_candidate.py \
-            --template candidates/stack-candidate-5.0.0-rc.4.template.json \
+            --template candidates/stack-candidate-5.0.0-rc.5.template.json \
             --openpine-sha "$GITHUB_SHA" \
             --created-at-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --builder github-actions \
             --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" \
             --source-uri "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            --output "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.4.json"
+            --output "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.5.json"
       - name: Resolve active stack candidate
         id: stack
         run: >-
@@ -69,42 +69,42 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.pine2ast_repo || 's7cret/pine2ast' }}
-          ref: ${{ steps.stack.outputs.pine2ast_sha || '1715eef9c395b81db24224b6724f16589c1c960a' }}
+          ref: ${{ steps.stack.outputs.pine2ast_sha || '325ddd17f4ced3c42739fa58bc902a927c2d4ac6' }}
           path: stack/pine2ast
           fetch-depth: 0
       - name: Checkout AST2Python
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.ast2python_repo || 's7cret/ast2python' }}
-          ref: ${{ steps.stack.outputs.ast2python_sha || 'ce8a691c6bdc8a1a1c81a2b8ed2cebb36e02da3b' }}
+          ref: ${{ steps.stack.outputs.ast2python_sha || 'df6783345ab7105334596b3685206a28e7f7e33e' }}
           path: stack/ast2python
           fetch-depth: 0
       - name: Checkout PineLib
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.pinelib_repo || 's7cret/pinelib' }}
-          ref: ${{ steps.stack.outputs.pinelib_sha || 'a0ea8e7177e73217c595f978c76ad34bb47d6bec' }}
+          ref: ${{ steps.stack.outputs.pinelib_sha || '1204d02ed5cea1a3be8b5e8252bc4d881c539a25' }}
           path: stack/pinelib
           fetch-depth: 0
       - name: Checkout Backtest Engine
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.backtest_engine_repo || 's7cret/backtest_engine' }}
-          ref: ${{ steps.stack.outputs.backtest_engine_sha || 'cc50cb425470265d95f6080854238b9bcda23830' }}
+          ref: ${{ steps.stack.outputs.backtest_engine_sha || '0a8a6a62e3556e9c3ef4cd0b5bcd048ce3cd62a0' }}
           path: stack/backtest_engine
           fetch-depth: 0
       - name: Checkout Marketdata Provider
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.marketdata_provider_repo || 's7cret/marketdata-provider' }}
-          ref: ${{ steps.stack.outputs.marketdata_provider_sha || 'e098947dfd30444273090e521e5c749673909c37' }}
+          ref: ${{ steps.stack.outputs.marketdata_provider_sha || 'de1cb68be33a9b51ee6ddf2513932c90af721874' }}
           path: stack/marketdata-provider
           fetch-depth: 0
       - name: Checkout Optimizer
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.optimizer_repo || 's7cret/optimizer' }}
-          ref: ${{ steps.stack.outputs.optimizer_sha || '1a6e8857d18ec072309bdf6d4832f56a6c3de6e4' }}
+          ref: ${{ steps.stack.outputs.optimizer_sha || '7687ad648502a5ab810779262850a7ae7abb3b71' }}
           path: stack/optimizer
           fetch-depth: 0
       - name: Exclude candidate checkouts from OpenPine source status
@@ -129,13 +129,13 @@ jobs:
           python scripts/finalize_stack_candidate.py \
             --candidate "$RUNNER_TEMP/openpine-candidate/${{ steps.stack.outputs.candidate_path }}" \
             --wheelhouse "$RUNNER_TEMP/openpine-candidate-verification" \
-            --output "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.4.wheels.json"
+            --output "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.5.wheels.json"
           rm -f "$RUNNER_TEMP/openpine-candidate/${{ steps.stack.outputs.candidate_path }}"
           python -m venv "$RUNNER_TEMP/openpine-candidate-venv"
           "$RUNNER_TEMP/openpine-candidate-venv/bin/python" -m pip install -U pip
           "$RUNNER_TEMP/openpine-candidate-venv/bin/python" \
             scripts/install_candidate_wheelhouse.py \
-            --candidate "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.4.wheels.json" \
+            --candidate "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.5.wheels.json" \
             --wheelhouse "$RUNNER_TEMP/openpine-candidate-verification" \
             --python "$RUNNER_TEMP/openpine-candidate-venv/bin/python" \
             --install
@@ -148,9 +148,9 @@ jobs:
         env:
           OPENPINE_BUILD_COMMIT: ${{ github.sha }}
           OPENPINE_PRODUCER_COMMITS_JSON: >-
-            {"pine2ast":"1715eef9c395b81db24224b6724f16589c1c960a","ast2python":"ce8a691c6bdc8a1a1c81a2b8ed2cebb36e02da3b","pinelib":"a0ea8e7177e73217c595f978c76ad34bb47d6bec","openpine-contracts":"9362f0abe1c4b0924f5f348141826e005cd880ba"}
+            {"pine2ast":"325ddd17f4ced3c42739fa58bc902a927c2d4ac6","ast2python":"df6783345ab7105334596b3685206a28e7f7e33e","pinelib":"1204d02ed5cea1a3be8b5e8252bc4d881c539a25","openpine-contracts":"6b5e67445e2772057cd877e158c7aa0c58bdfe37"}
         run: >-
-          OPENPINE_CANDIDATE_MANIFEST="$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.4.wheels.json"
+          OPENPINE_CANDIDATE_MANIFEST="$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.5.wheels.json"
           bash scripts/release_gate.sh
       - name: Type-check hardened API boundary
         run: >-

--- a/.github/workflows/stack-ci.yml
+++ b/.github/workflows/stack-ci.yml
@@ -33,13 +33,13 @@ jobs:
         run: |
           mkdir -p "$RUNNER_TEMP/openpine-candidate"
           python scripts/materialize_stack_candidate.py \
-            --template candidates/stack-candidate-5.0.0-rc.4.template.json \
+            --template candidates/stack-candidate-5.0.0-rc.5.template.json \
             --openpine-sha "$GITHUB_SHA" \
             --created-at-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --builder github-actions \
             --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" \
             --source-uri "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            --output "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.4.json"
+            --output "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.5.json"
       - name: Resolve active stack candidate
         id: stack
         working-directory: openpine
@@ -58,37 +58,37 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.pine2ast_repo || 's7cret/pine2ast' }}
-          ref: ${{ steps.stack.outputs.pine2ast_sha || 'c57323351a1e638e0337e1be247883da2570ab28' }}
+          ref: ${{ steps.stack.outputs.pine2ast_sha || '325ddd17f4ced3c42739fa58bc902a927c2d4ac6' }}
           path: pine2ast
       - name: Checkout AST2Python
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.ast2python_repo || 's7cret/ast2python' }}
-          ref: ${{ steps.stack.outputs.ast2python_sha || 'b3013b13a32a6e3eb68edc111390e35f206323fc' }}
+          ref: ${{ steps.stack.outputs.ast2python_sha || 'df6783345ab7105334596b3685206a28e7f7e33e' }}
           path: ast2python
       - name: Checkout PineLib
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.pinelib_repo || 's7cret/pinelib' }}
-          ref: ${{ steps.stack.outputs.pinelib_sha || 'a0ea8e7177e73217c595f978c76ad34bb47d6bec' }}
+          ref: ${{ steps.stack.outputs.pinelib_sha || '1204d02ed5cea1a3be8b5e8252bc4d881c539a25' }}
           path: pinelib
       - name: Checkout Backtest Engine
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.backtest_engine_repo || 's7cret/backtest_engine' }}
-          ref: ${{ steps.stack.outputs.backtest_engine_sha || 'cc50cb425470265d95f6080854238b9bcda23830' }}
+          ref: ${{ steps.stack.outputs.backtest_engine_sha || '0a8a6a62e3556e9c3ef4cd0b5bcd048ce3cd62a0' }}
           path: backtest_engine
       - name: Checkout Marketdata Provider
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.marketdata_provider_repo || 's7cret/marketdata-provider' }}
-          ref: ${{ steps.stack.outputs.marketdata_provider_sha || 'b868ace65524f5c3bf62498f667db411e299a4ce' }}
+          ref: ${{ steps.stack.outputs.marketdata_provider_sha || 'de1cb68be33a9b51ee6ddf2513932c90af721874' }}
           path: marketdata-provider
       - name: Checkout Optimizer
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.stack.outputs.optimizer_repo || 's7cret/optimizer' }}
-          ref: ${{ steps.stack.outputs.optimizer_sha || '73d67934d078cb97a4947cc7b0b12665c4086099' }}
+          ref: ${{ steps.stack.outputs.optimizer_sha || '7687ad648502a5ab810779262850a7ae7abb3b71' }}
           path: optimizer
       - name: Verify candidate checkout identities
         if: ${{ steps.stack.outputs.mode == 'candidate' }}
@@ -112,11 +112,11 @@ jobs:
           python openpine/scripts/finalize_stack_candidate.py \
             --candidate "$RUNNER_TEMP/openpine-candidate/${{ steps.stack.outputs.candidate_path }}" \
             --wheelhouse "$RUNNER_TEMP/openpine-wheelhouse" \
-            --output "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.4.wheels.json"
+            --output "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.5.wheels.json"
           python -m venv "$RUNNER_TEMP/openpine-candidate-venv"
           "$RUNNER_TEMP/openpine-candidate-venv/bin/python" \
             openpine/scripts/install_candidate_wheelhouse.py \
-            --candidate "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.4.wheels.json" \
+            --candidate "$RUNNER_TEMP/openpine-candidate/stack-candidate-5.0.0-rc.5.wheels.json" \
             --wheelhouse "$RUNNER_TEMP/openpine-wheelhouse" \
             --python "$RUNNER_TEMP/openpine-candidate-venv/bin/python" \
             --install
@@ -126,14 +126,14 @@ jobs:
           from importlib.metadata import version
 
           expected = {
-              'openpine': '5.0.0rc4',
-              'openpine-contracts': '5.0.0rc4',
-              'pine2ast': '5.0.0rc4',
-              'ast2python': '5.0.0rc4',
-              'pinelib': '5.0.0rc4',
-              'backtest-engine': '5.0.0rc4',
-              'marketdata-provider': '5.0.0rc4',
-              'optimizer': '5.0.0rc4',
+              'openpine': '5.0.0rc5',
+              'openpine-contracts': '5.0.0rc5',
+              'pine2ast': '5.0.0rc5',
+              'ast2python': '5.0.0rc5',
+              'pinelib': '5.0.0rc5',
+              'backtest-engine': '5.0.0rc5',
+              'marketdata-provider': '5.0.0rc5',
+              'optimizer': '5.0.0rc5',
           }
           for distribution, wanted in expected.items():
               installed = version(distribution)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.0.0rc5
+
+- Promotes the coordinated eight-repository 5.x stack with exact RC.5 package, source, wheel, and tree identities.
+- Makes migration 020 idempotent for the recognized legacy schema where `strategy_instances.semantic_profile` already exists, allowing safe production-copy upgrades from migration 19.
+- Ships the strict 5.x admission, isolated worker, Intent v2, broker projection, checkpoint, Bar v2, and trial-identity contracts with a conforming RC.5 stack lock.
+- Preserves fail-closed LIVE admission and the immutable production UI packaging boundary.
+
 ## 4.0.2
 
 - Added authenticated LAN-safe API/WebSocket access, immutable production UI packaging, strict browser/API contracts, and expanded backend/UI accessibility gates.

--- a/candidates/stack-candidate-5.0.0-rc.5.template.json
+++ b/candidates/stack-candidate-5.0.0-rc.5.template.json
@@ -1,6 +1,6 @@
 {
   "schema": "openpine.stack-candidate-template.v1",
-  "id": "5.0.0-rc.4",
+  "id": "5.0.0-rc.5",
   "not_a_release": true,
   "admission": {
     "capabilities": [
@@ -28,50 +28,50 @@
   "components": {
     "openpine-contracts": {
       "repo": "s7cret/openpine-contracts",
-      "ref": "feat/5.0-contracts",
-      "sha": "9362f0abe1c4b0924f5f348141826e005cd880ba",
-      "version": "5.0.0rc4"
+      "ref": "release/5.0.0rc5",
+      "sha": "6b5e67445e2772057cd877e158c7aa0c58bdfe37",
+      "version": "5.0.0rc5"
     },
     "marketdata-provider": {
       "repo": "s7cret/marketdata-provider",
-      "ref": "feat/5.0-bar-v2",
-      "sha": "e098947dfd30444273090e521e5c749673909c37",
-      "version": "5.0.0rc4"
+      "ref": "release/5.0.0rc5",
+      "sha": "de1cb68be33a9b51ee6ddf2513932c90af721874",
+      "version": "5.0.0rc5"
     },
     "pinelib": {
       "repo": "s7cret/pinelib",
-      "ref": "feat/5.0-intent-tape",
-      "sha": "a0ea8e7177e73217c595f978c76ad34bb47d6bec",
-      "version": "5.0.0rc4"
+      "ref": "release/5.0.0rc5",
+      "sha": "1204d02ed5cea1a3be8b5e8252bc4d881c539a25",
+      "version": "5.0.0rc5"
     },
     "backtest_engine": {
       "repo": "s7cret/backtest_engine",
-      "ref": "feat/5.0-warmup-reset",
-      "sha": "cc50cb425470265d95f6080854238b9bcda23830",
-      "version": "5.0.0rc4"
+      "ref": "release/5.0.0rc5",
+      "sha": "0a8a6a62e3556e9c3ef4cd0b5bcd048ce3cd62a0",
+      "version": "5.0.0rc5"
     },
     "pine2ast": {
       "repo": "s7cret/pine2ast",
-      "ref": "feat/5.0-contracts-pin",
-      "sha": "1715eef9c395b81db24224b6724f16589c1c960a",
-      "version": "5.0.0rc4"
+      "ref": "release/5.0.0rc5-pin",
+      "sha": "325ddd17f4ced3c42739fa58bc902a927c2d4ac6",
+      "version": "5.0.0rc5"
     },
     "ast2python": {
       "repo": "s7cret/ast2python",
-      "ref": "feat/5.0-contracts-pin",
-      "sha": "ce8a691c6bdc8a1a1c81a2b8ed2cebb36e02da3b",
-      "version": "5.0.0rc4"
+      "ref": "release/5.0.0rc5-pin",
+      "sha": "df6783345ab7105334596b3685206a28e7f7e33e",
+      "version": "5.0.0rc5"
     },
     "optimizer": {
       "repo": "s7cret/optimizer",
-      "ref": "feat/5.0-contracts-pin",
-      "sha": "1a6e8857d18ec072309bdf6d4832f56a6c3de6e4",
-      "version": "5.0.0rc4"
+      "ref": "release/5.0.0rc5-pin",
+      "sha": "7687ad648502a5ab810779262850a7ae7abb3b71",
+      "version": "5.0.0rc5"
     },
     "openpine": {
       "repo": "s7cret/openpine",
-      "ref": "feat/5.0-isolated-worker",
-      "version": "5.0.0rc4"
+      "ref": "release/5.0.0rc5",
+      "version": "5.0.0rc5"
     }
   }
 }

--- a/openpine/__init__.py
+++ b/openpine/__init__.py
@@ -1,3 +1,3 @@
 """OpenPine package."""
 
-__version__ = "5.0.0rc4"
+__version__ = "5.0.0rc5"

--- a/openpine/data/provider_adapter.py
+++ b/openpine/data/provider_adapter.py
@@ -23,7 +23,7 @@ from openpine.data.row_helpers import attr_or_item, duplicate_timestamps, has_an
 
 log = structlog.get_logger(__name__)
 
-REQUIRED_MARKETDATA_PROVIDER_VERSION = "5.0.0rc4"
+REQUIRED_MARKETDATA_PROVIDER_VERSION = "5.0.0rc5"
 
 
 class RuntimeDataProviderAdapter:

--- a/openpine/release.py
+++ b/openpine/release.py
@@ -21,7 +21,7 @@ from openpine.stack_lock import (
 from openpine.storage.migrations import _get_migration_files
 from openpine.storage.schema_indexes import REQUIRED_INDEXES
 
-REQUIRED_STACK_VERSION = "5.0.0rc4"
+REQUIRED_STACK_VERSION = "5.0.0rc5"
 CANONICAL_DOCS = {
     "docs/README.md",
     "docs/ARCHITECTURE.md",

--- a/openpine/stack-lock.json
+++ b/openpine/stack-lock.json
@@ -1,13 +1,13 @@
 {
   "schema": "openpine.stack-lock.v1",
-  "release": "4.0.2",
+  "release": "5.0.0rc5",
   "components": [
     {
       "name": "openpine",
       "package": "openpine",
       "repository": "s7cret/openpine",
-      "version": "4.0.2",
-      "tree_sha256": "4d7cf6bedeef9980ad2236d12b0b8e9c2d38451e19e6ba93446d4e42e63facd3",
+      "version": "5.0.0rc5",
+      "tree_sha256": "9c19b2a69324561d5f459aaa68ea77a70ae376bd0663bf55147804cd1570c6cb",
       "contracts": {
         "version_api": "openpine.version.v1"
       }
@@ -16,12 +16,12 @@
       "name": "pine2ast",
       "package": "pine2ast",
       "repository": "s7cret/pine2ast",
-      "version": "4.0.2",
-      "commit": "c57323351a1e638e0337e1be247883da2570ab28",
-      "tree_sha256": "4f05344a48aae9d90a4d94ec467bdea3d915b4ae24acca7faa1fe9320c581670",
+      "version": "5.0.0rc5",
+      "commit": "325ddd17f4ced3c42739fa58bc902a927c2d4ac6",
+      "tree_sha256": "6f8b72ac952b3f2e12b72a468c14bdabb30d0be298f95e7279176121df03ef64",
       "contracts": {
         "ast": "pine.ast_contract.v1",
-        "frontend": "openpine.frontend.v1",
+        "frontend": "openpine.frontend.v2",
         "runtime_profile": "runtime_contract_v1_4"
       }
     },
@@ -29,11 +29,12 @@
       "name": "ast2python",
       "package": "ast2python",
       "repository": "s7cret/ast2python",
-      "version": "4.0.2",
-      "commit": "b3013b13a32a6e3eb68edc111390e35f206323fc",
-      "tree_sha256": "3f71e33228a1dcee5bf52e130e45d1b26e4fae9a75f11eb41c304677807ca864",
+      "version": "5.0.0rc5",
+      "commit": "df6783345ab7105334596b3685206a28e7f7e33e",
+      "tree_sha256": "ed9c6c90ce64cc6df5851365e33c034ded2d10783f74c020603e798c5828f244",
       "contracts": {
         "ast": "pine.ast_contract.v1",
+        "generated_artifact": "openpine.generated_artifact.v2",
         "runtime": "1.4"
       }
     },
@@ -41,10 +42,11 @@
       "name": "pinelib",
       "package": "pinelib",
       "repository": "s7cret/pinelib",
-      "version": "4.0.2",
-      "commit": "fcf9c0f92213313db39bc42c83f676786c85400c",
-      "tree_sha256": "0f746ef57253621b546da75f50cc1d8a1ad29151fd75140d9088c682f654bd35",
+      "version": "5.0.0rc5",
+      "commit": "1204d02ed5cea1a3be8b5e8252bc4d881c539a25",
+      "tree_sha256": "c4ae65891b152a1ecdfce123704a43d1611dc923912292399c4d782cbbd713c1",
       "contracts": {
+        "intent": "openpine.intent.v2",
         "runtime": "1.4"
       }
     },
@@ -52,10 +54,12 @@
       "name": "backtest_engine",
       "package": "backtest-engine",
       "repository": "s7cret/backtest_engine",
-      "version": "4.0.2",
-      "commit": "329b9905bff2ea0b7b7f48662e4ce8b83d919c60",
-      "tree_sha256": "74332c1deda837fc0e4c7878897c1926f8ce7ff7ba876ffc9627dd87f58511d8",
+      "version": "5.0.0rc5",
+      "commit": "0a8a6a62e3556e9c3ef4cd0b5bcd048ce3cd62a0",
+      "tree_sha256": "772741709d7ee6d8231241a3bb918013fbba34ab7b9bb32bbccdf8ea873c1775",
       "contracts": {
+        "broker": "openpine.broker.v2",
+        "checkpoint": "openpine.checkpoint.v1",
         "tick_replay": "deterministic-explicit-v1"
       }
     },
@@ -63,10 +67,11 @@
       "name": "marketdata_provider",
       "package": "marketdata-provider",
       "repository": "s7cret/marketdata-provider",
-      "version": "4.0.2",
-      "commit": "b868ace65524f5c3bf62498f667db411e299a4ce",
-      "tree_sha256": "e7898ab7396365d2be685ae6138edd07ea2dacd84c340a9f83257ea05f82094d",
+      "version": "5.0.0rc5",
+      "commit": "de1cb68be33a9b51ee6ddf2513932c90af721874",
+      "tree_sha256": "91db52f653ab042917063dfef633bd289a4ba0a725c0e758f752ffd0973b855e",
       "contracts": {
+        "marketdata_bar": "openpine.marketdata.bar.v2",
         "runtime": "1.4",
         "segment_manifest": "stage-d-csv-2"
       }
@@ -75,10 +80,12 @@
       "name": "optimizer",
       "package": "optimizer",
       "repository": "s7cret/optimizer",
-      "version": "4.0.2",
-      "commit": "73d67934d078cb97a4947cc7b0b12665c4086099",
-      "tree_sha256": "c0f7e23b458d01eaf60e8891305a037482c5d79035d4b865e78589f5c9d8fb97",
-      "contracts": {}
+      "version": "5.0.0rc5",
+      "commit": "7687ad648502a5ab810779262850a7ae7abb3b71",
+      "tree_sha256": "3f586e50e152a6d5a07732e9412d11e7d138be6fbe570676125bc9e013c7ad8f",
+      "contracts": {
+        "trial_identity": "openpine.trial.identity.v1"
+      }
     }
   ]
 }

--- a/openpine/stack_lock.py
+++ b/openpine/stack_lock.py
@@ -222,6 +222,7 @@ def _pin_coherence_errors(lock: Mapping[str, Any], root: Path) -> list[str]:
     components = lock.get("components")
     if not isinstance(components, list):
         return errors
+    release = str(lock.get("release", ""))
     for item in components[1:]:
         if not isinstance(item, Mapping):
             continue
@@ -232,7 +233,11 @@ def _pin_coherence_errors(lock: Mapping[str, Any], root: Path) -> list[str]:
         expected_dependency = (
             f"{package} @ git+https://github.com/{repository}.git@{commit}"
         )
-        if expected_dependency not in dependencies:
+        expected_exact_dependency = f"{package}=={release}"
+        if (
+            expected_dependency not in dependencies
+            and expected_exact_dependency not in dependencies
+        ):
             errors.append(f"stack lock component {name} dependency ref does not match lock")
         for label, refs in workflow_refs.items():
             if refs.get(repository) != commit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openpine"
-version = "5.0.0rc4"
+version = "5.0.0rc5"
 description = "OpenPine product orchestration boundary for the Pine stack"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,13 +23,13 @@ dependencies = [
     "websockets>=14.0",
     "pandas>=2.0.0",
     "pyarrow>=15.0.0",
-    "pine2ast==5.0.0rc4",
-    "ast2python==5.0.0rc4",
-    "pinelib==5.0.0rc4",
-    "backtest-engine==5.0.0rc4",
-    "marketdata-provider==5.0.0rc4",
-    "optimizer==5.0.0rc4",
-    "openpine-contracts==5.0.0rc4",
+    "pine2ast==5.0.0rc5",
+    "ast2python==5.0.0rc5",
+    "pinelib==5.0.0rc5",
+    "backtest-engine==5.0.0rc5",
+    "marketdata-provider==5.0.0rc5",
+    "optimizer==5.0.0rc5",
+    "openpine-contracts==5.0.0rc5",
 ]
 
 [project.urls]

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -13,7 +13,7 @@ $PYTHON -m openpine.quality architecture openpine --max-lines 4000
 $PYTHON -m openpine.distribution manifest --root .
 $PYTHON scripts/verify_v5_sec_001.py
 candidate_manifest_path=${OPENPINE_CANDIDATE_MANIFEST:-}
-if [[ -z "$candidate_manifest_path" && -f candidates/stack-candidate-5.0.0-rc.4.template.json ]]; then
+if [[ -z "$candidate_manifest_path" && -f candidates/stack-candidate-5.0.0-rc.5.template.json ]]; then
     echo "materialized candidate manifest required: set OPENPINE_CANDIDATE_MANIFEST" >&2
     exit 1
 fi

--- a/scripts/verify_v5_sec_001.py
+++ b/scripts/verify_v5_sec_001.py
@@ -101,7 +101,7 @@ def _acceptance_manifest() -> dict[str, Any]:
     path = (
         Path(__file__).resolve().parents[1]
         / "candidates"
-        / "stack-candidate-5.0.0-rc.4.template.json"
+        / "stack-candidate-5.0.0-rc.5.template.json"
     )
     content = path.read_bytes()
     template = json.loads(content)

--- a/tests/admission_helpers.py
+++ b/tests/admission_helpers.py
@@ -18,7 +18,7 @@ def make_deployment_identity() -> DeploymentAdmissionIdentity:
         stack_id="test-stack",
         stack_manifest_hash=STACK_HASH,
         wheel_identities=tuple(
-            (name, "5.0.0rc4", "sha256:" + "a" * 64)
+            (name, "5.0.0rc5", "sha256:" + "a" * 64)
             for name in (
                 "openpine-contracts",
                 "marketdata-provider",
@@ -72,7 +72,7 @@ def make_sealed_artifact(
                 "schema_id": "openpine.generated_artifact.v2",
                 "schema_version": "2.0.0",
                 "producer": "ast2python",
-                "producer_version": "5.0.0-rc.4",
+                "producer_version": "5.0.0-rc.5",
                 "producer_commit": commits["ast2python"],
                 "stack_id": "openpine-5.0",
                 "created_at_utc_ms": 1,
@@ -86,7 +86,7 @@ def make_sealed_artifact(
                 ),
                 "source_map_hash": "sha256:" + "f" * 64,
                 "support_profile_hash": "sha256:" + "9" * 64,
-                "lowering_version": "5.0.0rc4",
+                "lowering_version": "5.0.0rc5",
                 "producer_commits": commits,
                 "semantic_profile": semantic_profile,
                 "required_runtime_capabilities": ["intent_tape_v2"],

--- a/tests/rc4_fixtures.py
+++ b/tests/rc4_fixtures.py
@@ -32,7 +32,7 @@ def admitted_manifest() -> dict[str, Any]:
     return {
         "schema": "openpine.stack-candidate.v2",
         "stage": "wheel-bound",
-        "id": "5.0.0-rc.4-test",
+        "id": "5.0.0-rc.5-test",
         "not_a_release": True,
         "manifest_hash": STACK_HASH,
         "components": {
@@ -84,7 +84,7 @@ def execution_context(
         "schema_id": "openpine.execution_context.v1",
         "schema_version": "1.0.0",
         "producer": "openpine",
-        "producer_version": "5.0.0-rc.4",
+        "producer_version": "5.0.0-rc.5",
         "producer_commit": _openpine_commit(),
         "stack_id": STACK_HASH,
         "created_at_utc_ms": 0,
@@ -95,7 +95,7 @@ def execution_context(
         "session_id": "session-test",
         "stack_manifest_hash": STACK_HASH,
         "wheel_identities": [
-            {"name": name, "version": "5.0.0rc4", "content_hash": HASH_B}
+            {"name": name, "version": "5.0.0rc5", "content_hash": HASH_B}
             for name in STACK_COMPONENTS
         ],
         "schema_hashes": {

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -29,14 +29,14 @@ def _candidate() -> dict:
     payload = {
         "schema": "openpine.stack-candidate.v2",
         "stage": "wheel-bound",
-        "id": "5.0.0-rc.4",
+        "id": "5.0.0-rc.5",
         "components": {
             "openpine": {
-                "version": "5.0.0rc4",
+                "version": "5.0.0rc5",
                 "wheel": {"filename": "openpine.whl", "sha256": HASH_B},
             },
             "openpine-contracts": {
-                "version": "5.0.0rc4",
+                "version": "5.0.0rc5",
                 "wheel": {"filename": "contracts.whl", "sha256": HASH_C},
             },
         },
@@ -60,8 +60,8 @@ def _run_identity(**updates: object) -> RunAdmissionIdentity:
     values: dict[str, object] = {
         "stack_manifest_hash": _candidate()["manifest_hash"],
         "wheel_identities": (
-            ("openpine", "5.0.0rc4", HASH_B),
-            ("openpine-contracts", "5.0.0rc4", HASH_C),
+            ("openpine", "5.0.0rc5", HASH_B),
+            ("openpine-contracts", "5.0.0rc5", HASH_C),
         ),
         "schema_hashes": {
             "openpine.run.v2": HASH_C,
@@ -150,9 +150,9 @@ def test_matching_stack_is_admitted() -> None:
 
 def test_candidate_deployment_identity_requires_wheel_schema_and_policy_evidence() -> None:
     deployment = deployment_identity_from_candidate(_candidate())
-    assert deployment.stack_id == "5.0.0-rc.4"
+    assert deployment.stack_id == "5.0.0-rc.5"
     assert deployment.stack_manifest_hash == _candidate()["manifest_hash"]
-    assert deployment.wheel_identities[0] == ("openpine", "5.0.0rc4", HASH_B)
+    assert deployment.wheel_identities[0] == ("openpine", "5.0.0rc5", HASH_B)
     assert deployment.schema_hashes["openpine.run.v2"] == HASH_C
 
     source = _candidate()
@@ -189,7 +189,7 @@ def test_active_deployment_verifies_wheel_bytes_installed_versions_and_schemas(
     candidate["manifest_hash"] = candidate_manifest_hash(candidate)
     path = tmp_path / "candidate.json"
     path.write_text(json.dumps(candidate), encoding="utf-8")
-    versions = {"openpine": "5.0.0rc4", "openpine-contracts": "5.0.0rc4"}
+    versions = {"openpine": "5.0.0rc5", "openpine-contracts": "5.0.0rc5"}
 
     deployment = load_active_deployment_identity(
         path,
@@ -228,7 +228,7 @@ def test_active_deployment_verifies_wheel_bytes_installed_versions_and_schemas(
 @pytest.mark.parametrize(
     ("updates", "expected"),
     [
-        ({"wheel_identities": (("openpine", "5.0.0rc4", HASH_D),)}, "wheel identities"),
+        ({"wheel_identities": (("openpine", "5.0.0rc5", HASH_D),)}, "wheel identities"),
         ({"schema_hashes": {"openpine.run.v2": HASH_D}}, "schema hashes"),
         ({"generated_artifact_hash": HASH_D}, "artifact hash mismatch"),
         ({"data_snapshot_hash": HASH_D}, "data snapshot hash mismatch"),

--- a/tests/test_candidate_dependency_closure.py
+++ b/tests/test_candidate_dependency_closure.py
@@ -24,7 +24,7 @@ def _source_candidate() -> dict:
     return materializer.materialize_candidate(
         {
             "schema": "openpine.stack-candidate-template.v1",
-            "id": "5.0.0-rc.4",
+            "id": "5.0.0-rc.5",
             "not_a_release": True,
             "admission": {
                 "capabilities": ["closed_bar", "deterministic_clock"],
@@ -38,18 +38,18 @@ def _source_candidate() -> dict:
                     "repo": "s7cret/pinelib",
                     "ref": "feat/5.0-intent-tape",
                     "sha": "a" * 40,
-                    "version": "5.0.0rc4",
+                    "version": "5.0.0rc5",
                 },
                 "openpine": {
                     "repo": "s7cret/openpine",
                     "ref": "feat/5.0-isolated-worker",
-                    "version": "5.0.0rc4",
+                    "version": "5.0.0rc5",
                 },
                 "openpine-contracts": {
                     "repo": "s7cret/openpine-contracts",
                     "ref": "feat/5.0-contracts",
                     "sha": "c" * 40,
-                    "version": "5.0.0rc4",
+                    "version": "5.0.0rc5",
                 },
             },
         },
@@ -63,7 +63,7 @@ def _wheel(
     directory: Path,
     *,
     name: str,
-    version: str = "5.0.0rc4",
+    version: str = "5.0.0rc5",
     requires: tuple[str, ...] = (),
     schemas: dict[str, bytes] | None = None,
 ) -> Path:
@@ -103,11 +103,11 @@ def test_finalize_binds_exact_wheels_and_dependency_closure(tmp_path: Path) -> N
     finalizer = _load("finalize_stack_candidate.py")
     resolver = _load("resolve_stack_candidate.py")
     _wheel(tmp_path, name="pinelib")
-    _wheel(tmp_path, name="openpine", requires=("pinelib==5.0.0rc4",))
+    _wheel(tmp_path, name="openpine", requires=("pinelib==5.0.0rc5",))
     _contracts_wheel(tmp_path)
 
     payload = finalizer.finalize_candidate(_source_candidate(), tmp_path)
-    path = tmp_path / "stack-candidate-5.0.0-rc.4.json"
+    path = tmp_path / "stack-candidate-5.0.0-rc.5.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
 
     assert payload["stage"] == "wheel-bound"

--- a/tests/test_candidate_materialization.py
+++ b/tests/test_candidate_materialization.py
@@ -22,7 +22,7 @@ def _load_script(name: str):
 def _template() -> dict[str, object]:
     return {
         "schema": "openpine.stack-candidate-template.v1",
-        "id": "5.0.0-rc.4",
+        "id": "5.0.0-rc.5",
         "not_a_release": True,
         "admission": {
             "capabilities": ["closed_bar", "deterministic_clock"],
@@ -36,12 +36,12 @@ def _template() -> dict[str, object]:
                 "repo": "s7cret/pinelib",
                 "ref": "feat/5.0-intent-tape",
                 "sha": "b" * 40,
-                "version": "5.0.0rc4",
+                "version": "5.0.0rc5",
             },
             "openpine": {
                 "repo": "s7cret/openpine",
                 "ref": "feat/5.0-isolated-worker",
-                "version": "5.0.0rc4",
+                "version": "5.0.0rc5",
             },
         },
     }
@@ -57,13 +57,13 @@ def test_materialized_candidate_binds_openpine_sha_and_manifest_hash(tmp_path: P
         created_at_utc="2026-08-20T21:00:00Z",
         provenance={"builder": "github-actions", "run_id": "123"},
     )
-    path = tmp_path / "stack-candidate-5.0.0-rc.4.json"
+    path = tmp_path / "stack-candidate-5.0.0-rc.5.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
 
     assert payload["schema"] == "openpine.stack-candidate.v2"
     assert payload["stage"] == "source"
     assert payload["components"]["openpine"]["sha"] == SHA
-    assert payload["components"]["openpine"]["version"] == "5.0.0rc4"
+    assert payload["components"]["openpine"]["version"] == "5.0.0rc5"
     assert payload["admission"]["capabilities"] == [
         "closed_bar",
         "deterministic_clock",
@@ -82,7 +82,7 @@ def test_materialized_candidate_hash_detects_tampering(tmp_path: Path) -> None:
         provenance={"builder": "github-actions", "run_id": "123"},
     )
     payload["components"]["pinelib"]["sha"] = "c" * 40
-    path = tmp_path / "stack-candidate-5.0.0-rc.4.json"
+    path = tmp_path / "stack-candidate-5.0.0-rc.5.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(resolver.CandidateSelectionError, match="manifest_hash"):
@@ -105,7 +105,7 @@ def test_template_is_not_discovered_as_an_active_candidate(tmp_path: Path) -> No
     resolver = _load_script("resolve_stack_candidate.py")
     template_dir = tmp_path / "candidates"
     template_dir.mkdir()
-    (template_dir / "stack-candidate-5.0.0-rc.4.template.json").write_text(
+    (template_dir / "stack-candidate-5.0.0-rc.5.template.json").write_text(
         json.dumps(_template()), encoding="utf-8"
     )
 

--- a/tests/test_candidate_metadata.py
+++ b/tests/test_candidate_metadata.py
@@ -23,12 +23,12 @@ def test_candidate_package_metadata_has_one_exact_version_truth() -> None:
         "project"
     ]
 
-    assert project["version"] == __version__ == "5.0.0rc4"
+    assert project["version"] == __version__ == "5.0.0rc5"
     dependencies = [str(item) for item in project["dependencies"]]
     stack_rows = {
         row.split("==", 1)[0]: row for row in dependencies if "==" in row
     }
     assert set(stack_rows) == STACK
-    assert all(row == f"{name}==5.0.0rc4" for name, row in stack_rows.items())
+    assert all(row == f"{name}==5.0.0rc5" for name, row in stack_rows.items())
     assert not any("git+" in row or " @ " in row for row in dependencies)
     assert _dependency_errors(project) == []

--- a/tests/test_canonical_snapshot_boundary.py
+++ b/tests/test_canonical_snapshot_boundary.py
@@ -15,7 +15,7 @@ from openpine.data.orchestrator import (
 )
 
 STACK_HASH = "sha256:" + "d" * 64
-COMMIT = "e098947dfd30444273090e521e5c749673909c37"
+COMMIT = "de1cb68be33a9b51ee6ddf2513932c90af721874"
 
 
 def _query() -> BarQuery:

--- a/tests/test_compile_pipeline.py
+++ b/tests/test_compile_pipeline.py
@@ -10,10 +10,10 @@ from openpine.config import OpenPineConfig
 from openpine.pine.source import PineSource
 
 COMMITS = {
-    "pine2ast": "1715eef9c395b81db24224b6724f16589c1c960a",
-    "ast2python": "ce8a691c6bdc8a1a1c81a2b8ed2cebb36e02da3b",
+    "pine2ast": "325ddd17f4ced3c42739fa58bc902a927c2d4ac6",
+    "ast2python": "df6783345ab7105334596b3685206a28e7f7e33e",
     "pinelib": "e5c69acaca70613734985f84a9ef9d28c1a12b79",
-    "openpine-contracts": "9362f0abe1c4b0924f5f348141826e005cd880ba",
+    "openpine-contracts": "6b5e67445e2772057cd877e158c7aa0c58bdfe37",
 }
 
 

--- a/tests/test_contracts_pin.py
+++ b/tests/test_contracts_pin.py
@@ -4,6 +4,6 @@ from openpine_contracts import list_schema_ids
 
 def test_contracts_pin_and_catalog() -> None:
     text = Path("pyproject.toml").read_text(encoding="utf-8")
-    assert '"openpine-contracts==5.0.0rc4"' in text
+    assert '"openpine-contracts==5.0.0rc5"' in text
     assert "git+" not in text
     assert "openpine.job.v1" in list_schema_ids()

--- a/tests/test_distribution_safety.py
+++ b/tests/test_distribution_safety.py
@@ -340,7 +340,7 @@ def test_stack_dependencies_are_immutable_and_ci_extras_are_complete() -> None:
         "openpine-contracts",
     }
     for name in direct_names:
-        assert f"{name}==5.0.0rc4" in dependencies
+        assert f"{name}==5.0.0rc5" in dependencies
     assert not any("git+" in dependency or " @ " in dependency for dependency in dependencies)
 
     dev_dependencies = config["project"]["optional-dependencies"]["dev"]

--- a/tests/test_install_candidate_wheelhouse.py
+++ b/tests/test_install_candidate_wheelhouse.py
@@ -93,14 +93,14 @@ def test_only_wheel_bound_candidate_can_supply_install_hashes() -> None:
         "components": {
             "pinelib": {
                 "wheel": {
-                    "filename": "pinelib-5.0.0rc4-py3-none-any.whl",
+                    "filename": "pinelib-5.0.0rc5-py3-none-any.whl",
                     "sha256": "sha256:" + "a" * 64,
                 }
             }
         },
     }
     assert mod.wheel_hashes_from_candidate(bound) == {
-        "pinelib-5.0.0rc4-py3-none-any.whl": "sha256:" + "a" * 64
+        "pinelib-5.0.0rc5-py3-none-any.whl": "sha256:" + "a" * 64
     }
 
 

--- a/tests/test_job_routes.py
+++ b/tests/test_job_routes.py
@@ -17,7 +17,7 @@ def _admission_identity() -> DeploymentAdmissionIdentity:
     return DeploymentAdmissionIdentity(
         stack_id="test-stack",
         stack_manifest_hash=STACK_HASH,
-        wheel_identities=(("openpine", "5.0.0rc4", "sha256:" + "a" * 64),),
+        wheel_identities=(("openpine", "5.0.0rc5", "sha256:" + "a" * 64),),
         schema_hashes={"openpine.run.v2": "sha256:" + "b" * 64},
         capabilities=frozenset({"closed_bar"}),
         semantic_profiles=frozenset({"strict_5x"}),

--- a/tests/test_release_gates.py
+++ b/tests/test_release_gates.py
@@ -144,35 +144,33 @@ def test_distribution_manifest_and_zip_are_deterministic(tmp_path: Path) -> None
     assert output.stat().st_size > 0
 
 
-def test_release_report_rejects_feature_tree_against_frozen_4_0_2_lock() -> None:
+def test_release_report_accepts_coherent_rc5_lock() -> None:
     root = Path(__file__).resolve().parents[1]
     _clean_release_artifacts(root)
     report = release_report(root)
 
-    assert __version__ == "5.0.0rc4"
-    assert report.ok is False
-    assert report.errors == (
-        "stack lock OpenPine tree_sha256 does not match package sources",
-    )
+    assert __version__ == "5.0.0rc5"
+    assert report.ok is True
+    assert report.errors == ()
     assert report.checks["latest_migration"] >= 10
 
 
-def test_frozen_stack_lock_stays_valid_but_not_coherent_with_feature_tree() -> None:
+def test_rc5_stack_lock_is_valid_and_coherent_with_release_tree() -> None:
     root = Path(__file__).resolve().parents[1]
     report = release_report(root)
     lock = load_stack_lock(root / "openpine" / "stack-lock.json")
     stack_checks = report.checks["stack_lock"]
 
     assert isinstance(stack_checks, dict)
-    assert report.ok is False
-    assert stack_checks["coherent"] is False
+    assert report.ok is True
+    assert stack_checks["coherent"] is True
     assert stack_checks["refs_verified"] is True
     assert stack_checks["valid"] is True
-    assert stack_checks["source_tree_matches"] is False
-    assert all(item["version"] == "4.0.2" for item in lock["components"])
+    assert stack_checks["source_tree_matches"] is True
+    assert all(item["version"] == "5.0.0rc5" for item in lock["components"])
     workflow = (root / ".github" / "workflows" / "stack-ci.yml").read_text()
-    assert "'openpine': '5.0.0rc4'" in workflow
-    assert "'openpine-contracts': '5.0.0rc4'" in workflow
+    assert "'openpine': '5.0.0rc5'" in workflow
+    assert "'openpine-contracts': '5.0.0rc5'" in workflow
 
 
 def test_release_report_returns_structured_failure_for_mapping_components(
@@ -221,9 +219,7 @@ def test_release_cli_writes_json(tmp_path: Path) -> None:
     output = tmp_path / "release.json"
 
     _clean_release_artifacts(root)
-    assert main(["--root", str(root), "--json", str(output)]) == 1
+    assert main(["--root", str(root), "--json", str(output)]) == 0
     payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["ok"] is False
-    assert payload["errors"] == [
-        "stack lock OpenPine tree_sha256 does not match package sources"
-    ]
+    assert payload["ok"] is True
+    assert payload["errors"] == []

--- a/tests/test_run_admission_integration.py
+++ b/tests/test_run_admission_integration.py
@@ -29,9 +29,9 @@ STACK_COMPONENTS = (
 
 def _deployment() -> DeploymentAdmissionIdentity:
     return DeploymentAdmissionIdentity(
-        stack_id="5.0.0-rc.4",
+        stack_id="5.0.0-rc.5",
         stack_manifest_hash=HASH_A,
-        wheel_identities=(("openpine", "5.0.0rc4", HASH_B),),
+        wheel_identities=(("openpine", "5.0.0rc5", HASH_B),),
         schema_hashes={"openpine.run.v2": HASH_C},
         capabilities=frozenset(
             {
@@ -60,10 +60,10 @@ def test_execution_context_is_derived_from_exact_deployment_and_manifest() -> No
         "openpine.checkpoint.proof.v1",
     )
     deployment = DeploymentAdmissionIdentity(
-        stack_id="5.0.0-rc.4",
+        stack_id="5.0.0-rc.5",
         stack_manifest_hash=HASH_A,
         wheel_identities=tuple(
-            (name, "5.0.0rc4", HASH_B) for name in STACK_COMPONENTS
+            (name, "5.0.0rc5", HASH_B) for name in STACK_COMPONENTS
         ),
         schema_hashes={name: HASH_C for name in schema_ids},
         capabilities=frozenset(
@@ -112,7 +112,7 @@ def test_execution_context_is_derived_from_exact_deployment_and_manifest() -> No
 
     validate_payload("openpine.execution_context.v1", context)
     assert verify_content_hash(context, schema_id="openpine.execution_context.v1")
-    assert context["producer_version"] == "5.0.0-rc.4"
+    assert context["producer_version"] == "5.0.0-rc.5"
     assert context["producer_commit"] == commits["openpine"]
     assert context["producer_commits"] == commits
     assert context["generated_artifact_hash"] == generated["content_hash"]
@@ -271,7 +271,7 @@ def test_run_identity_is_admitted_sealed_and_persisted_before_execution(
 
     monkeypatch.setattr(
         "openpine.run_identity.current_build_identity",
-        lambda: BuildIdentity(version="5.0.0rc4", commit="1" * 40),
+        lambda: BuildIdentity(version="5.0.0rc5", commit="1" * 40),
     )
     bars = [_bar(time=0), _bar(time=60_000)]
     artifact = _sealed_artifact()
@@ -312,7 +312,7 @@ def test_run_identity_is_admitted_sealed_and_persisted_before_execution(
 
     monkeypatch.setattr(
         "openpine.run_identity.current_build_identity",
-        lambda: BuildIdentity(version="5.0.0rc4", commit="2" * 40),
+        lambda: BuildIdentity(version="5.0.0rc5", commit="2" * 40),
     )
     with pytest.raises(AdmitError, match="producer commit"):
         admit_and_persist_run_identity(
@@ -510,10 +510,10 @@ def test_bind_isolated_execution_attaches_exact_protocol_inputs(tmp_path) -> Non
         "openpine.checkpoint.proof.v1",
     )
     deployment = DeploymentAdmissionIdentity(
-        stack_id="5.0.0-rc.4",
+        stack_id="5.0.0-rc.5",
         stack_manifest_hash=str(manifest["manifest_hash"]),
         wheel_identities=tuple(
-            (name, "5.0.0rc4", HASH_B) for name in STACK_COMPONENTS
+            (name, "5.0.0rc5", HASH_B) for name in STACK_COMPONENTS
         ),
         schema_hashes={name: HASH_C for name in schema_ids},
         capabilities=frozenset(

--- a/tests/test_stack_candidate.py
+++ b/tests/test_stack_candidate.py
@@ -7,11 +7,11 @@ import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
-TEMPLATE = ROOT / "candidates" / "stack-candidate-5.0.0-rc.4.template.json"
+TEMPLATE = ROOT / "candidates" / "stack-candidate-5.0.0-rc.5.template.json"
 HISTORICAL = (
     ROOT / "candidates" / "historical" / "stack-candidate-5.0.0-rc.2.json"
 )
-PIN = "9362f0abe1c4b0924f5f348141826e005cd880ba"
+PIN = "6b5e67445e2772057cd877e158c7aa0c58bdfe37"
 SHA40 = re.compile(r"^[0-9a-f]{40}$")
 REQUIRED = {
     "openpine-contracts",
@@ -49,13 +49,13 @@ def _materializer():
 def test_candidate_template_pins_eight_repos_and_is_not_active() -> None:
     payload = json.loads(TEMPLATE.read_text(encoding="utf-8"))
     assert payload["schema"] == "openpine.stack-candidate-template.v1"
-    assert payload["id"] == "5.0.0-rc.4"
+    assert payload["id"] == "5.0.0-rc.5"
     assert payload["not_a_release"] is True
     components = payload["components"]
     assert set(components) == REQUIRED
     assert components["openpine-contracts"]["sha"] == PIN
     for name, row in components.items():
-        assert row["version"] == "5.0.0rc4"
+        assert row["version"] == "5.0.0rc5"
         if name == "openpine":
             assert "sha" not in row
             continue
@@ -220,14 +220,14 @@ def test_candidate_resolver_emits_manifest_identity(tmp_path: Path) -> None:
         created_at_utc="2026-08-20T21:00:00Z",
         provenance={"builder": "test", "run_id": "1"},
     )
-    manifest = tmp_path / "stack-candidate-5.0.0-rc.4.json"
+    manifest = tmp_path / "stack-candidate-5.0.0-rc.5.json"
     manifest.write_text(json.dumps(payload), encoding="utf-8")
     outputs = dict(resolver.github_outputs(manifest))
 
     assert outputs["mode"] == "candidate"
     assert outputs["candidate_path"] == manifest.name
     assert outputs["pine2ast_repo"] == "s7cret/pine2ast"
-    assert outputs["pine2ast_sha"] == "1715eef9c395b81db24224b6724f16589c1c960a"
+    assert outputs["pine2ast_sha"] == "325ddd17f4ced3c42739fa58bc902a927c2d4ac6"
     assert outputs["openpine_sha"] == "d" * 40
 
 

--- a/tests/test_stack_lock.py
+++ b/tests/test_stack_lock.py
@@ -76,19 +76,19 @@ def test_transitive_pin_validation_rejects_stale_stack_dependency_refs() -> None
 def test_packaged_stack_lock_is_complete_and_immutable() -> None:
     lock = load_stack_lock()
     assert lock["schema"] == "openpine.stack-lock.v1"
-    assert lock["release"] == "4.0.2"
+    assert lock["release"] == "5.0.0rc5"
     assert [item["name"] for item in lock["components"]] == list(EXPECTED_COMPONENTS)
-    assert all(item["version"] == "4.0.2" for item in lock["components"])
+    assert all(item["version"] == "5.0.0rc5" for item in lock["components"])
     siblings = lock["components"][1:]
     assert all(re.fullmatch(r"(?!0{40})[0-9a-f]{40}", item["commit"]) for item in siblings)
     expected_tree_sha256 = {
-        "openpine": "4d7cf6bedeef9980ad2236d12b0b8e9c2d38451e19e6ba93446d4e42e63facd3",
-        "pine2ast": "4f05344a48aae9d90a4d94ec467bdea3d915b4ae24acca7faa1fe9320c581670",
-        "ast2python": "3f71e33228a1dcee5bf52e130e45d1b26e4fae9a75f11eb41c304677807ca864",
-        "pinelib": "0f746ef57253621b546da75f50cc1d8a1ad29151fd75140d9088c682f654bd35",
-        "backtest_engine": "74332c1deda837fc0e4c7878897c1926f8ce7ff7ba876ffc9627dd87f58511d8",
-        "marketdata_provider": "e7898ab7396365d2be685ae6138edd07ea2dacd84c340a9f83257ea05f82094d",
-        "optimizer": "c0f7e23b458d01eaf60e8891305a037482c5d79035d4b865e78589f5c9d8fb97",
+        "openpine": "9c19b2a69324561d5f459aaa68ea77a70ae376bd0663bf55147804cd1570c6cb",
+        "pine2ast": "6f8b72ac952b3f2e12b72a468c14bdabb30d0be298f95e7279176121df03ef64",
+        "ast2python": "ed9c6c90ce64cc6df5851365e33c034ded2d10783f74c020603e798c5828f244",
+        "pinelib": "c4ae65891b152a1ecdfce123704a43d1611dc923912292399c4d782cbbd713c1",
+        "backtest_engine": "772741709d7ee6d8231241a3bb918013fbba34ab7b9bb32bbccdf8ea873c1775",
+        "marketdata_provider": "91db52f653ab042917063dfef633bd289a4ba0a725c0e758f752ffd0973b855e",
+        "optimizer": "3f586e50e152a6d5a07732e9412d11e7d138be6fbe570676125bc9e013c7ad8f",
     }
     assert {
         item["name"]: item["tree_sha256"] for item in lock["components"]
@@ -97,9 +97,8 @@ def test_packaged_stack_lock_is_complete_and_immutable() -> None:
     assert "commit" not in self_identity
     assert re.fullmatch(r"(?!0{64})[0-9a-f]{64}", self_identity["tree_sha256"])
     root = Path(__file__).resolve().parents[1]
-    # The production 4.0.2 lock stays frozen while this checkout is a 5.0 candidate.
-    assert self_identity["tree_sha256"] != package_tree_identity(root / "openpine")
-    assert (root / "candidates" / "stack-candidate-5.0.0-rc.4.template.json").is_file()
+    assert self_identity["tree_sha256"] == package_tree_identity(root / "openpine")
+    assert (root / "candidates" / "stack-candidate-5.0.0-rc.5.template.json").is_file()
     assert validate_stack_lock(lock) == ()
 
 
@@ -169,6 +168,20 @@ def test_stack_lock_validation_checks_dependency_and_ci_refs(tmp_path: Path) -> 
         encoding="utf-8",
     )
 
+    assert validate_stack_lock(lock, root=root) == ()
+
+    exact_dependencies = [
+        f'    "{item["package"]}=={lock["release"]}",'
+        for item in lock["components"][1:]
+    ]
+    (root / "pyproject.toml").write_text(
+        "[project]\nname='openpine'\nversion='"
+        + lock["release"]
+        + "'\ndependencies=[\n"
+        + "\n".join(exact_dependencies)
+        + "\n]\n",
+        encoding="utf-8",
+    )
     assert validate_stack_lock(lock, root=root) == ()
 
     stack_workflow.write_text(
@@ -301,7 +314,7 @@ app.dependency_overrides[get_state] = lambda: SimpleNamespace()
 response = TestClient(app).get('/api/version')
 assert response.status_code == 200, response.text
 payload = response.json()
-assert payload['stack_lock']['release'] == '4.0.2'
+assert payload['stack_lock']['release'] == '5.0.0rc5'
 assert len(payload['stack_lock']['sha256']) == 64
 assert all(len(item['tree_sha256']) == 64 for item in payload['stack_lock']['components'])
 """

--- a/tests/test_version_manifest.py
+++ b/tests/test_version_manifest.py
@@ -30,7 +30,7 @@ def test_version_manifest_returns_tracked_modules_and_runtime() -> None:
     assert isinstance(payload["modules"], list)
     assert len(payload["modules"]) == 7
     assert payload["stack_lock"]["schema"] == "openpine.stack-lock.v1"
-    assert payload["stack_lock"]["release"] == "4.0.2"
+    assert payload["stack_lock"]["release"] == "5.0.0rc5"
     assert len(payload["stack_lock"]["sha256"]) == 64
     assert len(payload["stack_lock"]["components"]) == 7
 
@@ -65,12 +65,12 @@ def test_version_manifest_returns_tracked_modules_and_runtime() -> None:
     # openpine is the workspace checkout and is definitely installed here
     openpine = next(m for m in payload["modules"] if m["name"] == "openpine")
     assert openpine["installed"] is True
-    assert openpine["version"] == "5.0.0rc4"
-    assert openpine["distribution_version"] == "5.0.0rc4"
-    assert openpine["module_version"] == "5.0.0rc4"
-    assert openpine["conforms_to_lock"] is False
-    assert openpine["identity_conforms"] is False
-    assert payload["stack_conforms"] is False
+    assert openpine["version"] == "5.0.0rc5"
+    assert openpine["distribution_version"] == "5.0.0rc5"
+    assert openpine["module_version"] == "5.0.0rc5"
+    assert openpine["conforms_to_lock"] is True
+    assert openpine["identity_conforms"] is True
+    assert payload["stack_conforms"] is True
     assert openpine["path"] is not None
     assert openpine["path"].endswith("/openpine/__init__.py")
     assert openpine["summary"] is not None

--- a/tests/test_worker_protocol_transcript.py
+++ b/tests/test_worker_protocol_transcript.py
@@ -73,7 +73,7 @@ def test_transcript_builds_full_sealed_identity_stable_protocol_messages() -> No
         messages[2]["message_id"],
     ]
     assert messages[0]["producer"] == "openpine"
-    assert messages[0]["producer_version"] == "5.0.0-rc.4"
+    assert messages[0]["producer_version"] == "5.0.0-rc.5"
     for message in messages:
         validate_payload("openpine.worker.protocol.v2", message)
         assert message["schema_id"] == "openpine.worker.protocol.v2"


### PR DESCRIPTION
## Summary

- promote OpenPine and all exact internal dependencies to `5.0.0rc5`
- include the migration 020 idempotency fix merged at `42e1e5b1b705f1c51f582b39f84db9fce0a7814f`
- install a coherent RC.5 production stack lock with exact source and package-tree identities
- pin candidate/CI resolution to the seven exact RC.5 sibling heads
- preserve strict 5.x admission, isolated-worker security, and fail-closed LIVE behavior

## Exact stack heads

- Contracts `6b5e67445e2772057cd877e158c7aa0c58bdfe37`
- Marketdata `de1cb68be33a9b51ee6ddf2513932c90af721874`
- PineLib `1204d02ed5cea1a3be8b5e8252bc4d881c539a25`
- Backtest `0a8a6a62e3556e9c3ef4cd0b5bcd048ce3cd62a0`
- Pine2AST `325ddd17f4ced3c42739fa58bc902a927c2d4ac6`
- AST2Python `df6783345ab7105334596b3685206a28e7f7e33e`
- Optimizer `7687ad648502a5ab810779262850a7ae7abb3b71`
- OpenPine `af697b28b12b672ab46442ef9a3e9f6d241802d4`

## Verification

- full backend candidate release gate: PASS
- backend coverage: 91.09% (gate 90%)
- V5-SEC-001: PASS
- UI: 117 Vitest + 22 Node packaging/proxy tests PASS; production build PASS
- wheel-bound candidate: 8 exact wheels
- candidate manifest: `sha256:e45d9945c6624f8de02ed1354407dfc9bf6c42939147dd136f8bce2144613fc8`
- manifest file SHA-256: `b8f9163dac93674300d605ad02f1d9de4b22056790b1b904686657d5b671db67`
- OpenPine wheel SHA-256: `2705f8a16f7f9099d15f9133c11b8c2abc3ffe58f37c47dc1c1e345595f30d58`
- stack lock/source tree identity: PASS

Merge is deferred until exact-candidate sandbox acceptance and independent review are complete.
