### PR TITLE
fix(deploy): preserve immutable producer identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,23 @@ bash scripts/release_gate.sh
 
 The backend gate runs compileall, `ruff --select F,E9`, pytest+coverage, duplicate/architecture checks, distribution manifest, release manifest, and import smoke. UI audit/test/build is intentionally separate and should be run from `openpine-ui/`.
 
+### Immutable systemd producer identity
+
+Wheel deployments have no `.git` tree. Before installing `openpine-gateway.service`, render the non-secret producer identity file from the exact materialized stack candidate:
+
+```bash
+install -d -m 0750 /etc/openpine
+python scripts/render_immutable_identity_env.py \
+  --candidate /path/to/stack-candidate.wheels.json \
+  --output /etc/openpine/immutable-identity.env
+systemctl daemon-reload
+systemctl restart openpine-gateway.service
+```
+
+The renderer writes mode `0600` and binds JobV1, OpenPine, Pine2AST, AST2Python, PineLib, and Contracts producer SHAs. `openpine-gateway.service` requires this file after `/opt/openpine/.env`, so stale runtime variables cannot override immutable release identity. Keep API tokens only in `/opt/openpine/.env`; never add tokens to the generated identity file or Git.
+
+A compile submission returning `200 queued` is not final acceptance. Poll `/api/pine/compile/progress/{operation_id}` to `completed` and verify the Pine source has a non-null `active_artifact_id`.
+
 ## 4.0 Coverage Baseline
 
 The backend gate now enforces a 90% package coverage floor after the large CLI strategy/data lifecycle, marketdata provider-adapter, exchange-metadata, stream-adapter, TV-corpus, compare-helper, gateway/storage/execution, Telegram, runtime-adapter, optimizer-route, and gateway-lifespan, state CLI, Telegram polling, storage-adapter, and strategy lifecycle hardening pass. This is still a backend-only baseline for the product repository; later passes should continue raising it while decomposing the remaining legacy CLI, batch, live-runner, and Telegram surfaces.

--- a/openpine-gateway.service
+++ b/openpine-gateway.service
@@ -16,7 +16,11 @@ Environment=OPENPINE_WORKER_MAX_RESTARTS=3
 Environment=OPENPINE_WORKER_RESTART_WINDOW_SECONDS=300
 Environment=OPENPINE_WORKER_RESTART_BACKOFF_MAX_SECONDS=30
 EnvironmentFile=/opt/openpine/.env
-ExecStart=/opt/openpine/scripts/run_gateway_systemd.sh
+# Generated from the exact materialized candidate by
+# scripts/render_immutable_identity_env.py. Loaded last so stale runtime env
+# cannot override release producer identities; contains no API token.
+EnvironmentFile=/etc/openpine/immutable-identity.env
+ExecStart=/opt/openpine/scripts/run_gateway_systemd.sh --systemd-env-loaded
 Restart=on-failure
 RestartSec=5
 MemoryAccounting=yes

--- a/scripts/render_immutable_identity_env.py
+++ b/scripts/render_immutable_identity_env.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Render fail-closed producer identities for an immutable systemd deployment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "openpine.stack-candidate.v2"
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+HASH = re.compile(r"^sha256:[0-9a-f]{64}$")
+REQUIRED_COMPONENTS = (
+    "openpine",
+    "pine2ast",
+    "ast2python",
+    "pinelib",
+    "openpine-contracts",
+)
+COMPILER_COMPONENTS = (
+    "pine2ast",
+    "ast2python",
+    "pinelib",
+    "openpine-contracts",
+)
+
+
+class IdentityRenderError(RuntimeError):
+    """The candidate cannot provide an exact immutable producer identity."""
+
+
+def candidate_manifest_hash(candidate: Mapping[str, Any]) -> str:
+    unsigned = dict(candidate)
+    unsigned.pop("manifest_hash", None)
+    encoded = json.dumps(
+        {"domain": SCHEMA, "payload": unsigned},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _component_sha(components: Mapping[str, Any], name: str) -> str:
+    row = components.get(name)
+    if row is None:
+        raise IdentityRenderError(f"required component missing: {name}")
+    if not isinstance(row, Mapping):
+        raise IdentityRenderError(f"invalid component row: {name}")
+    sha = row.get("sha")
+    if not isinstance(sha, str) or SHA40.fullmatch(sha) is None:
+        raise IdentityRenderError(f"component sha must be 40 lowercase hex: {name}")
+    wheel = row.get("wheel")
+    if not isinstance(wheel, Mapping):
+        raise IdentityRenderError(f"component wheel identity missing: {name}")
+    filename = wheel.get("filename")
+    wheel_sha = wheel.get("sha256")
+    if not isinstance(filename, str) or not filename or Path(filename).name != filename:
+        raise IdentityRenderError(f"component wheel filename invalid: {name}")
+    if not isinstance(wheel_sha, str) or HASH.fullmatch(wheel_sha) is None:
+        raise IdentityRenderError(f"component wheel sha256 invalid: {name}")
+    return sha
+
+
+def render_identity_env(candidate: Mapping[str, Any]) -> str:
+    """Return the exact non-secret identity environment for *candidate*."""
+
+    if candidate.get("schema") != SCHEMA:
+        raise IdentityRenderError("materialized stack candidate required")
+    if candidate.get("stage") != "wheel-bound":
+        raise IdentityRenderError("wheel-bound candidate stage required")
+    recorded_hash = candidate.get("manifest_hash")
+    if not isinstance(recorded_hash, str) or HASH.fullmatch(recorded_hash) is None:
+        raise IdentityRenderError("candidate manifest_hash invalid")
+    if recorded_hash != candidate_manifest_hash(candidate):
+        raise IdentityRenderError("candidate manifest_hash mismatch")
+    components = candidate.get("components")
+    if not isinstance(components, Mapping):
+        raise IdentityRenderError("candidate components missing")
+
+    shas = {name: _component_sha(components, name) for name in REQUIRED_COMPONENTS}
+    compiler_commits = {name: shas[name] for name in COMPILER_COMPONENTS}
+    openpine_sha = shas["openpine"]
+    lines = (
+        f"OPENPINE_BUILD_COMMIT={openpine_sha}",
+        f"OPENPINE_DEPLOYMENT_COMMIT={openpine_sha}",
+        f"OPENPINE_PRODUCER_COMMIT={shas['pine2ast']}",
+        "OPENPINE_PRODUCER_COMMITS_JSON=" + json.dumps(compiler_commits, separators=(",", ":")),
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _write_private(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        handle = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+        raise
+    path.chmod(0o600)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        payload = json.loads(args.candidate.read_text(encoding="utf-8"))
+        if not isinstance(payload, Mapping):
+            raise IdentityRenderError("candidate must be a JSON object")
+        rendered = render_identity_env(payload)
+        _write_private(args.output, rendered)
+    except (OSError, json.JSONDecodeError, IdentityRenderError) as exc:
+        print(f"identity render failed: {exc}", file=sys.stderr)
+        return 2
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_gateway_systemd.sh
+++ b/scripts/run_gateway_systemd.sh
@@ -4,7 +4,17 @@ set -euo pipefail
 ROOT="${OPENPINE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$ROOT"
 
-if [[ -f .env ]]; then
+dotenv_loaded_by_systemd=false
+if [[ "${1:-}" == "--systemd-env-loaded" ]]; then
+  dotenv_loaded_by_systemd=true
+  shift
+fi
+if (( $# != 0 )); then
+  printf 'unexpected argument: %s\n' "$1" >&2
+  exit 2
+fi
+
+if [[ "$dotenv_loaded_by_systemd" == false && -f .env ]]; then
   set -a
   . ./.env
   set +a

--- a/tests/test_infra_hardening.py
+++ b/tests/test_infra_hardening.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 
 import pytest
 
-from openpine.notifications.telegram import TelegramBotHandler, TelegramCommandPlugin, TelegramPluginConfig
+from openpine.notifications.telegram import (
+    TelegramBotHandler,
+    TelegramCommandPlugin,
+    TelegramPluginConfig,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -51,12 +57,63 @@ def test_systemd_gateway_has_bounded_memory_and_worker_restart_policy() -> None:
 def test_systemd_gateway_runner_sources_env_in_current_shell() -> None:
     script = _read("scripts/run_gateway_systemd.sh")
 
+    assert '"${1:-}" == "--systemd-env-loaded"' in script
     assert "set -a" in script
     assert ". ./.env" in script or "source ./.env" in script
     assert "set +a" in script
     assert "(set -a" not in script
     assert 'exec "${OPENPINE_PYTHON:-python}"' in script
     assert "uvicorn.run(create_app()" in script
+
+
+def test_systemd_gateway_requires_immutable_identity_after_runtime_env() -> None:
+    unit = _read("openpine-gateway.service")
+
+    runtime_env = "EnvironmentFile=/opt/openpine/.env"
+    identity_env = "EnvironmentFile=/etc/openpine/immutable-identity.env"
+    assert runtime_env in unit
+    assert identity_env in unit
+    assert unit.index(runtime_env) < unit.index(identity_env)
+    assert "ExecStart=/opt/openpine/scripts/run_gateway_systemd.sh --systemd-env-loaded" in unit
+
+
+def test_systemd_runner_flag_prevents_dotenv_identity_override(tmp_path: Path) -> None:
+    expected = "a" * 40
+    (tmp_path / ".env").write_text(
+        "OPENPINE_BUILD_COMMIT=" + "b" * 40 + "\nOPENPINE_SKIP_DOTENV=0\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "result.txt"
+    fake_python = tmp_path / "fake-python"
+    fake_python.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$OPENPINE_BUILD_COMMIT" > "$OPENPINE_PROBE_OUTPUT"\n',
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o700)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "OPENPINE_ROOT": str(tmp_path),
+            "OPENPINE_PYTHON": str(fake_python),
+            "OPENPINE_BUILD_COMMIT": expected,
+            "OPENPINE_PROBE_OUTPUT": str(output),
+        }
+    )
+
+    result = subprocess.run(  # noqa: S603
+        [
+            "/usr/bin/bash",
+            str(ROOT / "scripts" / "run_gateway_systemd.sh"),
+            "--systemd-env-loaded",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text(encoding="utf-8").strip() == expected
 
 
 def test_telegram_poll_advances_offset_after_failed_update(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_render_immutable_identity_env.py
+++ b/tests/test_render_immutable_identity_env.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "render_immutable_identity_env.py"
+SCHEMA = "openpine.stack-candidate.v2"
+SHA = {
+    "openpine": "a" * 40,
+    "pine2ast": "b" * 40,
+    "ast2python": "c" * 40,
+    "pinelib": "d" * 40,
+    "openpine-contracts": "e" * 40,
+}
+
+
+def _seal(payload: dict[str, object]) -> None:
+    encoded = json.dumps(
+        {"domain": SCHEMA, "payload": payload},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    payload["manifest_hash"] = "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _component(name: str, sha: str) -> dict[str, object]:
+    return {
+        "sha": sha,
+        "version": "5.0.0rc5",
+        "wheel": {
+            "filename": f"{name}-5.0.0rc5-py3-none-any.whl",
+            "sha256": "sha256:" + hashlib.sha256(name.encode("utf-8")).hexdigest(),
+        },
+    }
+
+
+def _candidate(
+    tmp_path: Path,
+    *,
+    components: dict[str, dict[str, object]] | None = None,
+    stage: str = "wheel-bound",
+) -> Path:
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "stage": stage,
+        "components": components or {name: _component(name, sha) for name, sha in SHA.items()},
+    }
+    _seal(payload)
+    path = tmp_path / "candidate.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _run(candidate: Path, output: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(SCRIPT), "--candidate", str(candidate), "--output", str(output)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_renderer_emits_all_exact_non_secret_producer_identities(tmp_path: Path) -> None:
+    candidate = _candidate(tmp_path)
+    output = tmp_path / "immutable-identity.env"
+
+    result = _run(candidate, output)
+
+    assert result.returncode == 0, result.stderr
+    lines = output.read_text(encoding="utf-8").splitlines()
+    assert lines == [
+        f"OPENPINE_BUILD_COMMIT={SHA['openpine']}",
+        f"OPENPINE_DEPLOYMENT_COMMIT={SHA['openpine']}",
+        f"OPENPINE_PRODUCER_COMMIT={SHA['pine2ast']}",
+        "OPENPINE_PRODUCER_COMMITS_JSON="
+        + json.dumps(
+            {
+                "pine2ast": SHA["pine2ast"],
+                "ast2python": SHA["ast2python"],
+                "pinelib": SHA["pinelib"],
+                "openpine-contracts": SHA["openpine-contracts"],
+            },
+            separators=(",", ":"),
+        ),
+    ]
+    assert "TOKEN" not in output.read_text(encoding="utf-8")
+    assert output.stat().st_mode & 0o777 == 0o600
+
+
+def test_renderer_fails_closed_when_required_component_is_missing(tmp_path: Path) -> None:
+    components = {name: _component(name, sha) for name, sha in SHA.items() if name != "pine2ast"}
+    candidate = _candidate(tmp_path, components=components)
+    output = tmp_path / "immutable-identity.env"
+
+    result = _run(candidate, output)
+
+    assert result.returncode != 0
+    assert "required component missing: pine2ast" in result.stderr
+    assert not output.exists()
+
+
+def test_renderer_rejects_source_stage_candidate(tmp_path: Path) -> None:
+    candidate = _candidate(tmp_path, stage="source")
+    output = tmp_path / "immutable-identity.env"
+
+    result = _run(candidate, output)
+
+    assert result.returncode != 0
+    assert "wheel-bound candidate stage required" in result.stderr
+    assert not output.exists()
+
+
+def test_renderer_rejects_manifest_hash_drift(tmp_path: Path) -> None:
+    candidate = _candidate(tmp_path)
+    payload = json.loads(candidate.read_text(encoding="utf-8"))
+    payload["components"]["pine2ast"]["sha"] = "f" * 40
+    candidate.write_text(json.dumps(payload), encoding="utf-8")
+    output = tmp_path / "immutable-identity.env"
+
+    result = _run(candidate, output)
+
+    assert result.returncode != 0
+    assert "candidate manifest_hash mismatch" in result.stderr
+    assert not output.exists()
+
+
+def test_renderer_rejects_wheel_bound_candidate_without_wheel_identity(tmp_path: Path) -> None:
+    candidate = _candidate(tmp_path)
+    payload = json.loads(candidate.read_text(encoding="utf-8"))
+    del payload["components"]["pine2ast"]["wheel"]
+    payload.pop("manifest_hash")
+    _seal(payload)
+    candidate.write_text(json.dumps(payload), encoding="utf-8")
+    output = tmp_path / "immutable-identity.env"
+
+    result = _run(candidate, output)
+
+    assert result.returncode != 0
+    assert "component wheel identity missing: pine2ast" in result.stderr
+    assert not output.exists()
+
+
+def test_renderer_atomically_replaces_output_symlink_without_touching_target(
+    tmp_path: Path,
+) -> None:
+    candidate = _candidate(tmp_path)
+    target = tmp_path / "target.env"
+    target.write_text("sentinel\n", encoding="utf-8")
+    output = tmp_path / "immutable-identity.env"
+    output.symlink_to(target)
+
+    result = _run(candidate, output)
+
+    assert result.returncode == 0, result.stderr
+    assert target.read_text(encoding="utf-8") == "sentinel\n"
+    assert not output.is_symlink()
+    assert output.read_text(encoding="utf-8").startswith("OPENPINE_BUILD_COMMIT=")


### PR DESCRIPTION
## Summary
- derive immutable OpenPine and compiler producer identities from the exact wheel-bound stack candidate
- verify candidate manifest and component wheel identities, then atomically write a mode-0600 non-secret systemd environment file
- prevent the systemd runner from re-sourcing `.env` over immutable identities via a non-overridable argv mode
- document terminal Pine compile acceptance (`completed` plus `active_artifact_id`)

## Security / fail-closed behavior
- rejects non-wheel-bound, malformed, hash-drifted, or incomplete candidate manifests
- validates exact 40-hex producer SHAs and wheel SHA-256 identities
- replaces output atomically without following an existing output symlink
- does not read, render, or commit API tokens

## Verification
- [x] targeted deployment/renderer/architecture/packaged-lock tests
- [x] Ruff check and format
- [x] mypy
- [x] shellcheck / bash syntax and systemd-mode dotenv override probe
- [x] exact RC.5 manifest renders the effective live producer identities with mode 0600
- [x] full `scripts/release_gate.sh`
- [x] hosted PR CI

## Deployment note
This PR does not change the running RC.5 services and does not merge itself. It preserves the non-secret deployment procedure for future immutable installs.
